### PR TITLE
fix: stretch content of <sci-viewport> if it overflows horizontally

### DIFF
--- a/projects/scion/viewport/src/lib/viewport.component.scss
+++ b/projects/scion/viewport/src/lib/viewport.component.scss
@@ -1,13 +1,20 @@
 $scrollbar-size: 12px;
 
 :host {
+  --grid-template-columns: auto;
+  --grid-template-rows: auto;
+  --gap: 0 0;
+
   display: block;
   position: relative; // positioned anchor for viewport and scrollbars
   overflow: hidden;
 
   > div.viewport {
-    display: flex; // part of API
-    flex-flow: column nowrap; // part of API
+    display: grid; // part of API
+    grid-template-columns: var(--grid-template-columns);
+    grid-template-rows: var(--grid-template-rows);
+    gap: var(--gap);
+
     position: absolute;
     outline: none;
 

--- a/projects/scion/viewport/src/lib/viewport.component.ts
+++ b/projects/scion/viewport/src/lib/viewport.component.ts
@@ -15,7 +15,20 @@ import { NULL_DIMENSION, SciDimension } from '@scion/dimension';
  * Represents a viewport with its `<ng-content>` used as its scrollable viewport client and
  * scrollbars that sit on top of the viewport client.
  *
- * `ng-content` is added to a flex-box container with `flex-flow` set to 'column nowrap'.
+ * `ng-content` is added to a CSS grid container with a single column.
+ *
+ * You can override the following CSS properties:
+ *  --grid-template-columns
+ *  --grid-template-rows
+ *  --gap
+ *
+ *
+ * Example of how to control the CSS grid:
+ *
+ * sci-viewport {
+ *   --grid-template-columns: auto auto; // 2-column grid
+ *   --gap: .5em; // specifies the row and column gap
+ * }
  */
 @Component({
   selector: 'sci-viewport',

--- a/projects/scion/workbench/src/lib/activity-part/activity-part.component.scss
+++ b/projects/scion/workbench/src/lib/activity-part/activity-part.component.scss
@@ -88,11 +88,7 @@ $diamond-height: 8;
       flex: auto;
 
       wb-router-outlet {
-        flex: none;
-      }
-
-      wb-router-outlet + ::ng-deep * {
-        flex: 1 1 100%;
+        position: absolute; // take router outlet out of the document flow
       }
     }
 

--- a/projects/scion/workbench/src/lib/view/view.component.scss
+++ b/projects/scion/workbench/src/lib/view/view.component.scss
@@ -12,11 +12,7 @@
     height: 100%;
 
     wb-router-outlet {
-      flex: none;
-    }
-
-    wb-router-outlet + ::ng-deep * {
-      flex: 1 1 100%;
+      position: absolute; // take router outlet out of the document flow
     }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md#contribution)
- [ ] Tests for the changes have been added (required for routing or view grid related issues)
- [x] Public API has been documented

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Issue
Issue Number: #77 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## BREAKING CHANGE:
CSS display property of <sci-viewport> flex container has changed from `flex` (column nowrap) to `grid` (one column).

To migrate:
- if having a single content child which stretches vertically by using `flex: auto`, remove that property
- if having multiple content children with `flex: none`, wrap them inside a separate flex-container
