### PR TITLE
feat: provide API to simplify issuing custom intents from within client applications

### DIFF
--- a/projects/app/workbench-application-platform/host-app/src/app/custom-extension/custom-extension.module.ts
+++ b/projects/app/workbench-application-platform/host-app/src/app/custom-extension/custom-extension.module.ts
@@ -15,6 +15,7 @@ import { ACTIVITY_ACTION_PROVIDER, INTENT_HANDLER, MessageBoxIntentHandler, Noti
 import { ListNotificationComponent } from './list-notification/list-notification.component';
 import { CustomNotifyActivityActionComponent } from './custom-notify-activity-action/custom-notify-activity-action.component';
 import { CustomNotifyActivityActionProvider } from './custom-notify-activity-action/custom-notify-activity-action-provider.service';
+import { CustomIntentHandlerService } from './custom-intent/custom-intent-handler.service';
 
 @NgModule({
   declarations: [
@@ -46,6 +47,11 @@ import { CustomNotifyActivityActionProvider } from './custom-notify-activity-act
       useClass: CustomNotifyActivityActionProvider,
       multi: true
     },
+    {
+      provide: INTENT_HANDLER,
+      useClass: CustomIntentHandlerService,
+      multi: true
+    }
   ],
 })
 export class CustomExtensionModule {

--- a/projects/app/workbench-application-platform/host-app/src/app/custom-extension/custom-intent/custom-intent-handler.service.ts
+++ b/projects/app/workbench-application-platform/host-app/src/app/custom-extension/custom-intent/custom-intent-handler.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { IntentHandler, MessageBus } from '@scion/workbench-application-platform';
+import { NilQualifier, IntentMessage, MessageEnvelope } from '@scion/workbench-application-platform.api';
+
+@Injectable()
+export class CustomIntentHandlerService implements IntentHandler {
+
+  public readonly type = 'custom';
+  public readonly qualifier = NilQualifier;
+
+  public readonly description = 'Handles intents of type custom';
+
+  constructor(private _messageBus: MessageBus) {
+  }
+
+  public onIntent(envelope: MessageEnvelope<IntentMessage>): void {
+    this._messageBus.publishReply(envelope.message.payload, envelope.sender, envelope.replyToUid);
+  }
+}

--- a/projects/app/workbench-application-platform/testing-app/src/app/testing/custom-intent/custom-intent-panel.component.html
+++ b/projects/app/workbench-application-platform/testing-app/src/app/testing/custom-intent/custom-intent-panel.component.html
@@ -1,0 +1,5 @@
+<button (click)="onIssueIntent()" class="e2e-issue-intent">Issue Intent</button>
+
+<section class="close-action" *ngIf="result$ | async as result">
+  Result: <output class="e2e-result">{{result}}</output>
+</section>

--- a/projects/app/workbench-application-platform/testing-app/src/app/testing/custom-intent/custom-intent-panel.component.scss
+++ b/projects/app/workbench-application-platform/testing-app/src/app/testing/custom-intent/custom-intent-panel.component.scss
@@ -1,0 +1,4 @@
+:host {
+  display: grid;
+  grid-row-gap: .5em;
+}

--- a/projects/app/workbench-application-platform/testing-app/src/app/testing/custom-intent/custom-intent-panel.component.ts
+++ b/projects/app/workbench-application-platform/testing-app/src/app/testing/custom-intent/custom-intent-panel.component.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ */
+
+import { Component, OnDestroy } from '@angular/core';
+import { NilQualifier } from '@scion/workbench-application-platform.api';
+import { first, takeUntil } from 'rxjs/operators';
+import { Observable, Subject } from 'rxjs';
+import { IntentService } from '@scion/workbench-application.core';
+
+@Component({
+  selector: 'app-custom-intent-panel',
+  templateUrl: './custom-intent-panel.component.html',
+  styleUrls: ['./custom-intent-panel.component.scss'],
+})
+export class CustomIntentPanelComponent implements OnDestroy {
+
+  public result$: Observable<string>;
+  private _destroy$ = new Subject<void>();
+
+  constructor(private _intentService: IntentService) {
+  }
+
+  public onIssueIntent(): void {
+    this.result$ = this._intentService.issueIntent$<string>('custom', NilQualifier, 'custom-intent-payload')
+      .pipe(
+        first(),
+        takeUntil(this._destroy$)
+      );
+  }
+
+  public ngOnDestroy(): void {
+    this._destroy$.next();
+  }
+}

--- a/projects/app/workbench-application-platform/testing-app/src/app/testing/testing-view/testing-view.component.html
+++ b/projects/app/workbench-application-platform/testing-app/src/app/testing/testing-view/testing-view.component.html
@@ -45,6 +45,15 @@
     <app-message-box-panel></app-message-box-panel>
   </ng-template>
 
+  <!-- Custom Intents -->
+  <ng-template sciAccordionItem [panel]="custom_intent_panel" [cssClass]="'e2e-custom-intent-panel'">
+    <header>Custom Intents</header>
+  </ng-template>
+
+  <ng-template #custom_intent_panel>
+    <app-custom-intent-panel></app-custom-intent-panel>
+  </ng-template>
+
   <!-- Notification -->
   <ng-template sciAccordionItem [panel]="notification_panel" [cssClass]="'e2e-notification-panel'">
     <header>Notification</header>

--- a/projects/app/workbench-application-platform/testing-app/src/app/testing/testing.module.ts
+++ b/projects/app/workbench-application-platform/testing-app/src/app/testing/testing.module.ts
@@ -58,6 +58,7 @@ import { Activity5782ab19Component } from './activity-5782ab19/activity-5782ab19
 import { ViewOpenActivityActionPanelComponent } from './view-open-activity-action-panel/view-open-activity-action-panel.component';
 import { PopupOpenActivityActionPanelComponent } from './popup-open-activity-action-panel/popup-open-activity-action-panel.component';
 import { ViewC91805e8Component } from './view-c91805e8/view-c91805e8.component';
+import { CustomIntentPanelComponent } from './custom-intent/custom-intent-panel.component';
 
 @NgModule({
   declarations: [
@@ -65,6 +66,7 @@ import { ViewC91805e8Component } from './view-c91805e8/view-c91805e8.component';
     ViewNavigationPanelComponent,
     ViewInterationPanelComponent,
     MessageBoxPanelComponent,
+    CustomIntentPanelComponent,
     NotificationPanelComponent,
     PopupPanelComponent,
     TestingPopupComponent,

--- a/projects/app/workbench-application-platform/testing-app/src/assets/manifest.json
+++ b/projects/app/workbench-application-platform/testing-app/src/assets/manifest.json
@@ -652,6 +652,9 @@
   ],
   "intents": [
     {
+      "type": "custom"
+    },
+    {
       "type": "messagebox"
     },
     {

--- a/projects/e2e/workbench-application-platform/src/custom-intent.e2e-spec.ts
+++ b/projects/e2e/workbench-application-platform/src/custom-intent.e2e-spec.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ */
+
+import { TestingViewPO } from './page-object/testing-view.po';
+import { browser } from 'protractor';
+
+describe('CustomIntent', () => {
+  const testingViewPO = new TestingViewPO();
+
+  beforeEach(async () => {
+    await browser.get('/');
+  });
+
+  it('should return result when custom intent is dispatched', async () => {
+    await testingViewPO.navigateTo();
+    const panelPO = await testingViewPO.openCustomIntentPanel();
+
+    await panelPO.issueIntent();
+    await expect(panelPO.getResult()).toEqual('custom-intent-payload');
+  });
+});

--- a/projects/e2e/workbench-application-platform/src/page-object/custom-intent-panel.po.ts
+++ b/projects/e2e/workbench-application-platform/src/page-object/custom-intent-panel.po.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms from the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ */
+
+import { $ } from 'protractor';
+import { switchToIFrameContext } from '../util/testing.util';
+
+export class CustomIntentPanelPO {
+
+  private _panel = $('app-custom-intent-panel');
+
+  constructor(public iframeContext: string[]) {
+  }
+
+  public async getResult(): Promise<string> {
+    await switchToIFrameContext(this.iframeContext);
+    return this._panel.$('output.e2e-result').getText();
+  }
+
+  public async issueIntent(): Promise<void> {
+    await switchToIFrameContext(this.iframeContext);
+    await this._panel.$('button.e2e-issue-intent').click();
+  }
+}

--- a/projects/e2e/workbench-application-platform/src/page-object/testing-view.po.ts
+++ b/projects/e2e/workbench-application-platform/src/page-object/testing-view.po.ts
@@ -17,6 +17,7 @@ import { SciAccordionPO } from './sci-accordion-p.o';
 import { switchToIFrameContext } from '../util/testing.util';
 import { MessageBoxPanelPO } from './message-box-panel.po';
 import { NotificationPanelPO } from './notification-panel.po';
+import { CustomIntentPanelPO } from './custom-intent-panel.po';
 
 const E2E_TESTING_VIEW_CONTEXT: string[] = ['e2e-testing-app', 'e2e-view', 'e2e-testing-view'];
 
@@ -55,6 +56,12 @@ export class TestingViewPO {
     await switchToIFrameContext(E2E_TESTING_VIEW_CONTEXT);
     await new SciAccordionPO().toggle(this._component.$('sci-accordion'), 'e2e-message-box-panel', true);
     return new MessageBoxPanelPO(E2E_TESTING_VIEW_CONTEXT);
+  }
+
+  public async openCustomIntentPanel(): Promise<CustomIntentPanelPO> {
+    await switchToIFrameContext(E2E_TESTING_VIEW_CONTEXT);
+    await new SciAccordionPO().toggle(this._component.$('sci-accordion'), 'e2e-custom-intent-panel', true);
+    return new CustomIntentPanelPO(E2E_TESTING_VIEW_CONTEXT);
   }
 
   public async openNotificationPanel(): Promise<NotificationPanelPO> {

--- a/projects/scion/workbench-application.angular/src/lib/workbench-application.module.ts
+++ b/projects/scion/workbench-application.angular/src/lib/workbench-application.module.ts
@@ -14,7 +14,7 @@ import { WorkbenchUrlOpenActivityActionDirective } from './workbench-url-open-ac
 import { WorkbenchRouterLinkDirective, WorkbenchRouterLinkWithHrefDirective } from './workbench-router-link.directive';
 import { WorkbenchApplicationConfig } from './workbench-application.config';
 import { ActivatorService } from './activator.service';
-import { DefaultMessageBus, ManifestRegistryService, MessageBoxService, MessageBus, NotificationService, Platform, PopupService } from '@scion/workbench-application.core';
+import { DefaultMessageBus, IntentService, ManifestRegistryService, MessageBoxService, MessageBus, NotificationService, Platform, PopupService } from '@scion/workbench-application.core';
 import { ForRootGuardService } from './for-root-guard.service';
 import { WorkbenchPopupOpenActivityActionDirective } from './workbench-popup-open-activity-action.directive';
 
@@ -69,6 +69,10 @@ export class WorkbenchApplicationModule {
           useFactory: provideNotificationService
         },
         {
+          provide: IntentService,
+          useFactory: provideIntentService
+        },
+        {
           provide: ManifestRegistryService,
           useFactory: provideManifestRegistryService
         },
@@ -117,6 +121,10 @@ export function provideNotificationService(): NotificationService {
 
 export function provideMessageBoxService(): MessageBoxService {
   return Platform.getService(MessageBoxService);
+}
+
+export function provideIntentService(): IntentService {
+  return Platform.getService(IntentService);
 }
 
 export function provideManifestRegistryService(): ManifestRegistryService {

--- a/projects/scion/workbench-application.core/src/lib/intent-service.ts
+++ b/projects/scion/workbench-application.core/src/lib/intent-service.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ */
+
+import { MessageBus } from './message-bus-service';
+import { Service } from './metadata';
+import { Platform } from './platform';
+import { IntentMessage, Qualifier } from '@scion/workbench-application-platform.api';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * Allows issuing an intent to interact with the platform.
+ */
+export class IntentService implements Service {
+  /**
+   * Issues an intent to the application platform and returns a stream of replies.
+   * The returned observable never completes. It is up to the caller to unsubscribe from the stream.
+   * @returns a stream of replies.
+   */
+  public issueIntent$<T>(type: string, qualifier?: Qualifier, payload?: any): Observable<T> {
+    const intentMessage: IntentMessage = {type, qualifier, payload};
+
+    return Platform.getService(MessageBus).requestReceive$({channel: 'intent', message: intentMessage})
+      .pipe(map(replyEnvelope => replyEnvelope && replyEnvelope.message));
+  }
+
+  /**
+   * Issues an intent to the application platform without returning a reply.
+   */
+  public issueIntent(type: string, qualifier?: Qualifier, payload?: any): void {
+    const intentMessage: IntentMessage = {type, qualifier, payload};
+
+    return Platform.getService(MessageBus).postMessage({channel: 'intent', message: intentMessage});
+  }
+
+  public onDestroy(): void {
+    // noop
+  }
+}

--- a/projects/scion/workbench-application.core/src/lib/platform-activator.ts
+++ b/projects/scion/workbench-application.core/src/lib/platform-activator.ts
@@ -18,6 +18,7 @@ import { RouterService } from './router.service';
 import { Platform } from './platform';
 import { PopupService } from './popup-service';
 import { PlatformEventBus } from './platform-event-bus-service';
+import { IntentService } from './intent-service';
 
 /**
  * Manages the lifecycle of this workbench application module to communicate with the workbench application platform.
@@ -40,6 +41,7 @@ export class PlatformActivator {
     Platform.register(new NotificationService());
     Platform.register(new PopupService());
     Platform.register(new ManifestRegistryService());
+    Platform.register(new IntentService());
 
     window.addEventListener('beforeunload', () => this.stop(), {once: true});
   }

--- a/projects/scion/workbench-application.core/src/public_api.ts
+++ b/projects/scion/workbench-application.core/src/public_api.ts
@@ -20,6 +20,7 @@ export * from './lib/view.service';
 export * from './lib/activity.service';
 export * from './lib/message-box-service';
 export * from './lib/notification-service';
+export * from './lib/intent-service';
 export * from './lib/popup-service';
 export * from './lib/manifest-registryService';
 export * from './lib/metadata';

--- a/resources/site/how-to/workbench-application-platform/how-to-install-a-programmatic-intent-handler.md
+++ b/resources/site/how-to/workbench-application-platform/how-to-install-a-programmatic-intent-handler.md
@@ -54,6 +54,10 @@ export class CustomIntentHandler implements IntentHandler {
 |➄|Optional lifecycle hook that is called after the platform completed registration of applications.<br>Use this method to handle any initialization tasks which require the application or manifest registry.|
 |➅|Method invoked upon the receipt of an intent.|
 
+## How to issue intents to the programmatic intent handler
+
+On how to interact with your own intent handler from the client application, see [How to issue a custom intent](how-to-issue-custom-intent.md)
+
 [menu-overview]: /README.md
 [menu-workbench]: /resources/site/workbench.md
 [menu-workbench-application-platform]: /resources/site/workbench-application-platform.md

--- a/resources/site/how-to/workbench-application-platform/how-to-issue-custom-intent.md
+++ b/resources/site/how-to/workbench-application-platform/how-to-issue-custom-intent.md
@@ -1,0 +1,50 @@
+![SCION Workbench](/resources/site/logo/scion-workbench-banner.png)
+
+[Overview][menu-overview] | [Workbench][menu-workbench] | [Workbench&nbsp;Application&nbsp;Platform][menu-workbench-application-platform] | [Contributing][menu-contributing] | [Changelog][menu-changelog] | [Sponsoring][menu-sponsoring] | [Links][menu-links]
+|---|---|---|---|---|---|---|
+
+## How to issue a custom intent
+
+The workbench application platform provides an API to register [programmatic intent handlers](how-to-install-a-programmatic-intent-handler.md) in the host application. 
+A child application can then use the `IntentService` to issue a respective intent by providing the intents type and qualifier if any. Also, you can provide a payload if required by the other side. As those intents are generic, a client has to know what qualifier and payload he has to provide and what the response will be.
+
+The `IntentService` provides two methods:
+
+|method|description|
+|-|-|
+|issueIntent$|This method issues an intent to the platform and returns a stream of replies. The response type has to be provided by the caller (see the example below)|
+|issueIntent|This method issues an intent without expecting a reply (fire & forget)|
+
+### Example with stream of replies
+```typescript
+constructor(private _intentService: IntentService) { } 
+
+public onIssueIntent(): void {
+   this.result$ = this._intentService.issueIntent$<string>('my-type', {'entity': 'example'}, 'my-payload')
+   .pipe(
+     takeUntil(this._$destroy) // the client has to cleanup his subscription onDestroy
+   )
+}
+```
+
+### Example with exactly one response
+```typescript
+constructor(private _intentService: IntentService) { } 
+
+public onIssueIntent(): void {
+   this.result$ = this._intentService.issueIntent$<string>('my-type', {'entity': 'example'}, 'my-payload')
+    .pipe(
+      first() // as the client knows that only one reply will be sent, he can terminate the subscription immediately
+    )
+}
+```
+
+> For non Angular applications, get the intent service via `Platform.getService(IntentService)`.
+
+[menu-overview]: /README.md
+[menu-workbench]: /resources/site/workbench.md
+[menu-workbench-application-platform]: /resources/site/workbench-application-platform.md
+[menu-contributing]: /CONTRIBUTING.md
+[menu-changelog]: /resources/site/changelog.md
+[menu-sponsoring]: /resources/site/sponsors.md
+[menu-links]: /resources/site/links.md

--- a/resources/site/how-to/workbench-application-platform/how-to.md
+++ b/resources/site/how-to/workbench-application-platform/how-to.md
@@ -13,7 +13,7 @@ This section provides answers to some common questions when integrating applicat
 - [How to register applications](how-to-register-applications.md)
 - [How to configure routing in the host application](how-to-configure-routing-in-the-host-application.md)
 - [How to install a programmatic intent handler](how-to-install-a-programmatic-intent-handler.md)
-- [How to install a custom error handler ](how-to-install-a-custom-error-handler.md)
+- [How to install a custom error handler](how-to-install-a-custom-error-handler.md)
 - [How to provide a custom activity action](how-to-provide-a-custom-activity-action.md)
 - [How to integrate DevTools](how-to-integrate-devtools.md)
 
@@ -38,6 +38,7 @@ This section provides answers to some common questions when integrating applicat
 - [How to prevent view destruction](how-to-prevent-view-destruction.md)
 - [How to make a capability private or public scope](how-to-make-a-capability-private-or-public-scope.md)
 - [How to configure focus handling](how-to-configure-focus-handling.md)
+- [How to issue a custom intent](how-to-issue-custom-intent.md)
 
 
 ***


### PR DESCRIPTION
Provides the ability to issue custom intents in the client API. This can
be used to trigger custom intent handlers in the host application.

fixes #96

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md#contribution)
- [x] Tests for the changes have been added (required for routing or view grid related issues)
- [x] Public API has been documented

## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Issue
Issue Number: 96

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

