### PR TITLE
feat: support for merging parameters in self navigation

### DIFF
--- a/apps/workbench-client-testing-app/src/app/view-page/view-page.component.html
+++ b/apps/workbench-client-testing-app/src/app/view-page/view-page.component.html
@@ -96,12 +96,29 @@
   </ng-template>
 </sci-accordion>
 
-<sci-accordion class="update-view-params e2e-update-view-params" variant="solid">
-  <ng-template sciAccordionItem [panel]="panel_update_view_params">
-    <header>Update View Params</header>
-  </ng-template>
-  <ng-template #panel_update_view_params>
-    <sci-params-enter [paramsFormArray]="viewParamsControl" [addable]="true" [removable]="true" class="e2e-view-params"></sci-params-enter>
-    <button (click)="onUpdateViewParams()" class="update-view-params e2e-update-view-params">Update</button>
-  </ng-template>
-</sci-accordion>
+<ng-container [formGroup]="form">
+  <sci-accordion class="self-navigation e2e-self-navigation" variant="solid" [formGroupName]="SELF_NAVIGATION">
+    <ng-template sciAccordionItem [panel]="panel_self_navigation">
+      <header>Self-Navigation</header>
+    </ng-template>
+    <ng-template #panel_self_navigation>
+      <sci-form-field label="Params">
+        <sci-params-enter [paramsFormArray]="$any(form.get([SELF_NAVIGATION, PARAMS]))" [addable]="true" [removable]="true" class="e2e-params"></sci-params-enter>
+      </sci-form-field>
+
+      <sci-form-field label="ParamsHandling">
+        <select [formControlName]="PARAMS_HANDLING" class="e2e-param-handling">
+          <option value="merge">merge</option>
+          <option value="replace">replace</option>
+          <option value="">default</option>
+        </select>
+      </sci-form-field>
+
+      <sci-form-field label="Navigate per Param" title="Check to simulate the performing of bulk navigations">
+        <sci-checkbox [formControlName]="NAVIGATE_PER_PARAM" class="e2e-navigate-per-param"></sci-checkbox>
+      </sci-form-field>
+
+      <button (click)="onSelfNavigate()" class="navigate-self e2e-navigate-self">Perform self-navigation</button>
+    </ng-template>
+  </sci-accordion>
+</ng-container>

--- a/apps/workbench-client-testing-app/src/app/view-page/view-page.component.scss
+++ b/apps/workbench-client-testing-app/src/app/view-page/view-page.component.scss
@@ -40,7 +40,7 @@
       }
     }
 
-    &.update-view-params button.update-view-params {
+    &.self-navigation button.navigate-self {
       margin-top: .5em;
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1809,17 +1809,17 @@
       }
     },
     "@scion/toolkit": {
-      "version": "11.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@scion/toolkit/-/toolkit-11.0.0-beta.6.tgz",
-      "integrity": "sha512-Ne0NTcjKoxV4mc32i+YmT36wp/nn+hOV7BeQu2hPqUx2JNPQOA2MkPb+TWy3m06hqATh+iBMDuY2LxAEFD/6Xg==",
+      "version": "11.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@scion/toolkit/-/toolkit-11.0.0-beta.7.tgz",
+      "integrity": "sha512-bNe2m/eV9KNRGkNlLVrEVdnOqTfdDAqIWPGR6ToXaJHWgbJZM2dpgtJtNwb6+tdyu9pA+ACVRZzEGIgoPUFNvw==",
       "requires": {
         "tslib": "^2.0.0"
       }
     },
     "@scion/toolkit.internal": {
-      "version": "11.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@scion/toolkit.internal/-/toolkit.internal-11.0.0-beta.6.tgz",
-      "integrity": "sha512-By++WC8Mts73EKBaOnWXqF8lDetPbJwfHh+x5Z4xnbzy7M+QJ+l6pjVRHlwICXyqWHDwWpNh2R7EZYLekMtGSQ==",
+      "version": "11.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@scion/toolkit.internal/-/toolkit.internal-11.0.0-beta.7.tgz",
+      "integrity": "sha512-aL4sfUWT8lwXfXBS27pJuzoyd3qWTmoeIF3k6XTl4w/iX1LL7DcRFaSSwAXFfxAWBzqnURmktZIsKACWANCwnA==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "@angular/platform-browser-dynamic": "11.0.0",
     "@angular/router": "11.0.0",
     "@scion/microfrontend-platform": "1.0.0-beta.11",
-    "@scion/toolkit": "11.0.0-beta.6",
-    "@scion/toolkit.internal": "11.0.0-beta.6",
+    "@scion/toolkit": "11.0.0-beta.7",
+    "@scion/toolkit.internal": "11.0.0-beta.7",
     "rxjs": "6.6.0",
     "tslib": "2.0.0",
     "zone.js": "0.10.3"

--- a/projects/scion/e2e-testing/src/workbench-client/page-object/view-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/page-object/view-page.po.ts
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: EPL-2.0
  */
 
-import { assertPageToDisplay, enterText } from '../../helper/testing.util';
+import { assertPageToDisplay, enterText, selectOption } from '../../helper/testing.util';
 import { AppPO, ViewPO, ViewTabPO } from '../../app.po';
 import { SciAccordionPO, SciCheckboxPO, SciParamsEnterPO, SciPropertyPO } from '@scion/toolkit.internal/widgets.po';
 import { $, ElementFinder } from 'protractor';
@@ -201,17 +201,19 @@ export class ViewPagePO {
     // do not close the accordion as this action removes the iframe from the DOM.
   }
 
-  public async updateViewParams(params: Params): Promise<void> {
+  public async navigateSelf(params: Params, options?: {paramsHandling?: 'merge' | 'replace', navigatePerParam?: boolean}): Promise<void> {
     await WebdriverExecutionContexts.switchToIframe(this.viewId);
     await assertPageToDisplay(this._pageFinder);
 
-    const accordionPO = new SciAccordionPO(this._pageFinder.$('sci-accordion.e2e-update-view-params'));
+    const accordionPO = new SciAccordionPO(this._pageFinder.$('sci-accordion.e2e-self-navigation'));
     await accordionPO.expand();
     try {
-      const paramsEnterPO = new SciParamsEnterPO(this._pageFinder.$('sci-params-enter.e2e-view-params'));
+      const paramsEnterPO = new SciParamsEnterPO(this._pageFinder.$('sci-accordion.e2e-self-navigation').$('sci-params-enter.e2e-params'));
       await paramsEnterPO.clear();
       await paramsEnterPO.enterParams(params);
-      await this._pageFinder.$('button.e2e-update-view-params').click();
+      await selectOption(options?.paramsHandling || '', this._pageFinder.$('sci-accordion.e2e-self-navigation').$('select.e2e-param-handling'));
+      await new SciCheckboxPO(this._pageFinder.$('sci-checkbox.e2e-navigate-per-param')).toggle(options?.navigatePerParam ?? false);
+      await this._pageFinder.$('sci-accordion.e2e-self-navigation').$('button.e2e-navigate-self').click();
     }
     finally {
       await accordionPO.collapse();

--- a/projects/scion/e2e-testing/src/workbench-client/router-params.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/router-params.e2e-spec.ts
@@ -191,31 +191,209 @@ describe('Workbench Router', () => {
     await expect(await testeeViewPagePO.getComponentInstanceId()).toEqual(testeeComponentInstanceId);
   });
 
-  it('should allow updating the current view\'s params by not passing a qualifier for navigation', async () => {
-    await appPO.navigateTo({microfrontendSupport: true});
+  describe('Self-Navigation', () => {
 
-    const viewPagePO = await ViewPagePO.openInNewTab('app1');
-    const componentInstanceId = await viewPagePO.getComponentInstanceId();
+    it('should, by default, replace params', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
 
-    await viewPagePO.updateViewParams({
-      param1: 'PARAM 1',
-      param2: 'PARAM 2',
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      const componentInstanceId = await viewPagePO.getComponentInstanceId();
+
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: 'PARAM 2',
+        param3: 'PARAM 3 (a)',
+      });
+
+      // expect the view's params to be updated
+      await expect(await viewPagePO.getViewParams()).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param2: 'PARAM 2', param3: 'PARAM 3 (a)'}));
+      // expect the component to be the same instance
+      await expect(await viewPagePO.getComponentInstanceId()).toEqual(componentInstanceId);
+
+      await viewPagePO.navigateSelf({
+        param3: 'PARAM 3 (b)',
+        param4: 'PARAM 4',
+        param5: 'PARAM 5',
+      });
+
+      // expect the view's params to be updated
+      const params = await viewPagePO.getViewParams();
+      await expect(params).toEqual(jasmine.objectContaining({param3: 'PARAM 3 (b)', param4: 'PARAM 4', param5: 'PARAM 5'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param1: 'PARAM 1'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param2: 'PARAM 2'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param3: 'PARAM 3 (a)'}));
+
+      // expect the component to be the same instance
+      await expect(await viewPagePO.getComponentInstanceId()).toEqual(componentInstanceId);
     });
 
-    // expect the view's params to be updated
-    await expect(await viewPagePO.getViewParams()).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param2: 'PARAM 2'}));
-    // expect the component to be the same instance
-    await expect(await viewPagePO.getComponentInstanceId()).toEqual(componentInstanceId);
+    it('should replace params', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
 
-    await viewPagePO.updateViewParams({
-      param3: 'PARAM 3',
-      param4: 'PARAM 4',
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      const componentInstanceId = await viewPagePO.getComponentInstanceId();
+
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: 'PARAM 2',
+        param3: 'PARAM 3 (a)',
+      });
+
+      // expect the view's params to be updated
+      await expect(await viewPagePO.getViewParams()).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param2: 'PARAM 2', param3: 'PARAM 3 (a)'}));
+      // expect the component to be the same instance
+      await expect(await viewPagePO.getComponentInstanceId()).toEqual(componentInstanceId);
+
+      await viewPagePO.navigateSelf({
+        param3: 'PARAM 3 (b)',
+        param4: 'PARAM 4',
+        param5: 'PARAM 5',
+      }, {paramsHandling: 'replace'});
+
+      // expect the view's params to be updated
+      const params = await viewPagePO.getViewParams();
+      await expect(params).toEqual(jasmine.objectContaining({param3: 'PARAM 3 (b)', param4: 'PARAM 4', param5: 'PARAM 5'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param1: 'PARAM 1'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param2: 'PARAM 2'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param3: 'PARAM 3 (a)'}));
+      // expect the component to be the same instance
+      await expect(await viewPagePO.getComponentInstanceId()).toEqual(componentInstanceId);
     });
 
-    // expect the view's params to be updated
-    await expect(await viewPagePO.getViewParams()).toEqual(jasmine.objectContaining({param3: 'PARAM 3', param4: 'PARAM 4'}));
-    await expect(await viewPagePO.getViewParams()).not.toEqual(jasmine.objectContaining({param1: 'PARAM 1', param2: 'PARAM 2'}));
-    // expect the component to be the same instance
-    await expect(await viewPagePO.getComponentInstanceId()).toEqual(componentInstanceId);
+    it('should merge params', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      const componentInstanceId = await viewPagePO.getComponentInstanceId();
+
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: 'PARAM 2',
+        param3: 'PARAM 3 (a)',
+      });
+
+      // expect the view's params to be updated
+      await expect(await viewPagePO.getViewParams()).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param2: 'PARAM 2', param3: 'PARAM 3 (a)'}));
+      // expect the component to be the same instance
+      await expect(await viewPagePO.getComponentInstanceId()).toEqual(componentInstanceId);
+
+      await viewPagePO.navigateSelf({
+        param3: 'PARAM 3 (b)',
+        param4: 'PARAM 4',
+        param5: 'PARAM 5',
+      }, {paramsHandling: 'merge'});
+
+      // expect the view's params to be updated
+      const params = await viewPagePO.getViewParams();
+      await expect(params).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param2: 'PARAM 2', param3: 'PARAM 3 (b)', param4: 'PARAM 4', param5: 'PARAM 5'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param3: 'PARAM 3 (a)'}));
+      // expect the component to be the same instance
+      await expect(await viewPagePO.getComponentInstanceId()).toEqual(componentInstanceId);
+    });
+
+    it('should correctly merge params when performing bulk navigations', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: 'PARAM 2',
+        param3: 'PARAM 3',
+        param4: 'PARAM 4',
+        param5: 'PARAM 5',
+      }, {paramsHandling: 'merge', navigatePerParam: true});
+
+      // expect the view's params to be updated
+      await expect(await viewPagePO.getViewParams()).toEqual(jasmine.objectContaining({
+        param1: 'PARAM 1',
+        param2: 'PARAM 2',
+        param3: 'PARAM 3',
+        param4: 'PARAM 4',
+        param5: 'PARAM 5',
+      }));
+    });
+
+    it('should correctly replace params when performing bulk navigations', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: 'PARAM 2',
+        param3: 'PARAM 3',
+        param4: 'PARAM 4',
+        param5: 'PARAM 5',
+      }, {paramsHandling: 'replace', navigatePerParam: true});
+
+      // expect the view's params to be updated
+      const params = await viewPagePO.getViewParams();
+      await expect(params).not.toEqual(jasmine.objectContaining({param1: 'PARAM 1'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param2: 'PARAM 2'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param3: 'PARAM 3'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param4: 'PARAM 4'}));
+      await expect(params).toEqual(jasmine.objectContaining({param5: 'PARAM 5'}));
+    });
+
+    it('should remove params having `undefined` as value [paramsHandling=replace]', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: '<undefined>',
+        param3: 'PARAM 3',
+      }, {paramsHandling: 'replace'});
+
+      // expect the view's params to be updated
+      const params = await viewPagePO.getViewParams();
+      await expect(params).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param3: 'PARAM 3'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param2: jasmine.anything()}));
+    });
+
+    it('should remove params having `undefined` as their value [paramsHandling=merge]', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: '<undefined>',
+        param3: 'PARAM 3',
+      }, {paramsHandling: 'merge'});
+
+      // expect the view's params to be updated
+      const params = await viewPagePO.getViewParams();
+      await expect(params).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param3: 'PARAM 3'}));
+      await expect(params).not.toEqual(jasmine.objectContaining({param2: jasmine.anything()}));
+    });
+
+    it('should not remove params having `null` as their value [paramsHandling=replace]', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: '<null>',
+        param3: 'PARAM 3',
+      }, {paramsHandling: 'replace'});
+
+      // expect the view's params to be updated
+      const params = await viewPagePO.getViewParams();
+      await expect(params).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param2: 'null', param3: 'PARAM 3'}));
+    });
+
+    it('should remove params having `null` as their value [paramsHandling=merge]', async () => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      const viewPagePO = await ViewPagePO.openInNewTab('app1');
+      await viewPagePO.navigateSelf({
+        param1: 'PARAM 1',
+        param2: '<null>',
+        param3: 'PARAM 3',
+      }, {paramsHandling: 'merge'});
+
+      // expect the view's params to be updated
+      const params = await viewPagePO.getViewParams();
+      await expect(params).toEqual(jasmine.objectContaining({param1: 'PARAM 1', param2: 'null', param3: 'PARAM 3'}));
+    });
   });
 });

--- a/projects/scion/e2e-testing/src/workbench-client/view.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/view.e2e-spec.ts
@@ -109,7 +109,7 @@ describe('Workbench View', () => {
     ]));
 
     // update params (no microfrontend change)
-    await testeeViewPagePO.updateViewParams({param1: 'param-1'});
+    await testeeViewPagePO.navigateSelf({param1: 'param-1'});
 
     // expect following Observables to complete
     await expect(await consumeBrowserLog(Level.DEBUG, /ObservableComplete/)).toEqual([]);

--- a/projects/scion/workbench-client/package.json
+++ b/projects/scion/workbench-client/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "rxjs": "^6.0.0",
-    "@scion/toolkit": ">=11.0.0-beta.6",
+    "@scion/toolkit": ">=11.0.0-beta.7",
     "@scion/microfrontend-platform": ">= 1.0.0-beta.11"
   },
   "keywords": [

--- a/projects/scion/workbench-client/src/lib/routing/workbench-router-navigate-command.ts
+++ b/projects/scion/workbench-client/src/lib/routing/workbench-router-navigate-command.ts
@@ -10,6 +10,7 @@
 
 import { WorkbenchViewCapability } from '../view/workbench-view-capability';
 import { WorkbenchNavigationExtras } from './workbench-router';
+import { Qualifier } from '@scion/microfrontend-platform';
 
 /**
  * Command object for instructing the Workbench Router to navigate to the microfrontend of given view capabilities.
@@ -20,6 +21,7 @@ import { WorkbenchNavigationExtras } from './workbench-router';
 export interface ɵWorkbenchRouterNavigateCommand { // tslint:disable-line:class-name
   capabilities: WorkbenchViewCapability[];
   extras: WorkbenchNavigationExtras;
+  qualifier: Qualifier;
 }
 
 /**

--- a/projects/scion/workbench-client/src/lib/routing/workbench-router.ts
+++ b/projects/scion/workbench-client/src/lib/routing/workbench-router.ts
@@ -47,8 +47,10 @@ export class WorkbenchRouter {
    * If multiple view capabilities match the qualifier, they are all opened.
    *
    * @param  qualifier - Identifies the view capability that provides the microfrontend.
-   *                     When navigating in the context of a view, you can pass an empty qualifier to navigate to the current view again, e.g.,
-   *                     to update view parameters to reflect the view state in the URL.
+   *                     By passing an empty qualifier (`{}`), the currently loaded view can update its parameters in the workbench URL, e.g., to support
+   *                     persistent navigation. This type of navigation is referred to as self-navigation and is supported only if in the context
+   *                     of a view. Setting {@link WorkbenchNavigationExtras#paramsHandling} allows instructing the workbench router how to handle
+   *                     params. By default, new params replace params contained in the URL.
    * @param  extras - Options to control navigation.
    * @return Promise that resolves to `true` when navigation succeeds, to `false` when navigation fails, or is rejected on error,
    *         e.g., if not qualified or because no application provides the requested view.
@@ -78,27 +80,29 @@ export class WorkbenchRouter {
       const {intent, capability} = await this.currentNavigation();
       return {
         capabilities: [capability],
-        extras: this.constructNavigationExtras(intent.qualifier, extras),
+        extras: {
+          ...extras,
+          target: 'self',
+          selfViewId: Beans.get(WorkbenchView).viewId,
+          params: {
+            ...Dictionaries.coerce(extras?.params),
+            ...intent.qualifier, // Qualifier entries have precedence and cannot be overwritten by params
+          },
+          paramsHandling: extras?.paramsHandling ?? 'replace',
+        },
       };
     }
-    else {
-      return {
-        capabilities: await this.lookupViewCapabilities(qualifier),
-        extras: this.constructNavigationExtras(qualifier, extras),
-      };
-    }
-  }
 
-  /**
-   * Constructs navigation extras based on the given extras to instrument the Workbench Router.
-   */
-  private constructNavigationExtras(qualifier: Qualifier, extras: WorkbenchNavigationExtras | undefined): WorkbenchNavigationExtras {
     return {
-      ...extras,
-      selfViewId: extras?.selfViewId ?? Beans.opt(WorkbenchView)?.viewId,
-      params: {
-        ...Dictionaries.coerce(extras?.params),
-        ...qualifier,
+      capabilities: await this.lookupViewCapabilities(qualifier),
+      extras: {
+        ...extras,
+        selfViewId: extras?.selfViewId ?? Beans.opt(WorkbenchView)?.viewId,
+        params: {
+          ...Dictionaries.coerce(extras?.params),
+          ...qualifier, // Qualifier entries have priority, i.e., they cannot be overwritten by params.
+        },
+        paramsHandling: undefined, // `paramsHandling` cannot be set for navigations other than self-navigation
       },
     };
   }
@@ -115,16 +119,15 @@ export class WorkbenchRouter {
   }
 
   private async currentNavigation(): Promise<CurrentNavigation> {
-    const view = Beans.opt(WorkbenchView);
-    if (!view) {
-      throw Error('[NullViewContextError] Navigating to the current view requires you to be in the context of a view.');
-    }
+    const view = Beans.get(WorkbenchView);
     const currentCapability = await view.capability$
       .pipe(take(1))
       .toPromise();
     const currentParams = await view.params$
       .pipe(take(1))
       .toPromise();
+
+    // Derive the qualifier of the current view. We can't just use the qualifier of the capability since it might contain wildcards.
     const currentIntentQualifier = Object.keys(currentCapability.qualifier).reduce((acc, key) => {
       if (!currentParams.has(key)) {
         throw Error(`[ViewContextError] Missing required qualifier param '${key}'.`);
@@ -143,9 +146,15 @@ export class WorkbenchRouter {
   }
 
   /**
-   * Checks whether requesting a self navigation, e.g., for updating params to be reflected in the top-level URL (persistent workbench navigation).
+   * Checks whether requesting a self-navigation.
+   *
+   * Self-navigation must be performed in the context of a view, allowing a view to update its parameters in the workbench URL
+   * to support persistent navigation. A self-navigation is initiated by passing an empty qualifier.
    */
   private isSelfNavigation(qualifier: Qualifier): boolean {
+    if (!Beans.opt(WorkbenchView)) {
+      return false;
+    }
     return !qualifier || Object.keys(qualifier).length === 0;
   }
 }
@@ -162,6 +171,20 @@ export interface WorkbenchNavigationExtras {
    * If the fulfilling capability(-ies) declare(s) mandatory parameters, be sure to include them, otherwise navigation will be rejected.
    */
   params?: Map<string, any> | Dictionary;
+
+  /**
+   * Instructs the workbench router how to handle params in self-navigation.
+   *
+   * Self-navigation allows a view to update its parameters in the workbench URL to support persistent navigation. Setting a `paramsHandling`
+   * strategy has no effect on navigations other than self-navigation. A self-navigation is initiated by passing an empty qualifier.
+   *
+   * One of:
+   * * `replace`: Discards parameters in the URL and uses the new parameters instead (which is by default if not set).
+   * * `merge`:   Merges new parameters with the parameters currently contained in the URL. In case of a key collision, new parameters overwrite
+   *              the parameters contained in the URL. A parameter can be removed by passing `undefined` as its value.
+   */
+  paramsHandling?: 'merge' | 'replace' | undefined;
+
   /**
    * Activates the view if present. Note that you can only activate views for which you have an intention and which are visible to your app.
    * If no qualified view is present, the requested view is opened according to the specified target strategy.
@@ -174,8 +197,9 @@ export interface WorkbenchNavigationExtras {
   /**
    * Controls where to open the view.
    *
-   * 'self':    opens the view in the current view tab (which is by default)
-   * 'blank':   opens the view in a new view tab
+   * One of:
+   * * `self`:  Opens the microfrontend in the current view tab, replacing the currently displaying microfrontend (which is by default if not set).
+   * * `blank`: Opens the microfrontend in a new view tab.
    */
   target?: 'self' | 'blank';
   /**

--- a/projects/scion/workbench-client/src/lib/view/workbench-view.ts
+++ b/projects/scion/workbench-client/src/lib/view/workbench-view.ts
@@ -56,7 +56,7 @@ export abstract class WorkbenchView {
    * navigating to a microfrontend of another app. Consequently, do not forget to unsubscribe from this Observables before displaying
    * another microfrontend.
    */
-  public readonly params$: Observable<Map<string, string>>;
+  public readonly params$: Observable<Map<string, any>>;
 
   /**
    * Indicates whether this is the active view in its view part.
@@ -143,13 +143,13 @@ export class ɵWorkbenchView implements WorkbenchView, PreDestroy { // tslint:di
 
   public active$: Observable<boolean>;
   public capability$: Observable<WorkbenchViewCapability>;
-  public params$: Observable<Map<string, string>>;
+  public params$: Observable<Map<string, any>>;
 
   constructor(public viewId: string) {
     this._beforeUnload$ = Beans.get(MessageClient).observe$<void>(ɵWorkbenchCommands.viewUnloadingTopic(this.viewId))
       .pipe(mapTo(undefined));
 
-    this.params$ = Beans.get(MessageClient).observe$<Map<string, string>>(ɵWorkbenchCommands.viewParamsTopic(this.viewId))
+    this.params$ = Beans.get(MessageClient).observe$<Map<string, any>>(ɵWorkbenchCommands.viewParamsTopic(this.viewId))
       .pipe(
         mapToBody(),
         coerceMap(),

--- a/projects/scion/workbench/package.json
+++ b/projects/scion/workbench/package.json
@@ -24,7 +24,7 @@
     "@angular/animations": "^11.0.0-rc.0 || ^11.0.0",
     "@angular/forms": "^11.0.0-rc.0 || ^11.0.0",
     "@angular/router": "^11.0.0-rc.0 || ^11.0.0",
-    "@scion/toolkit": ">=11.0.0-beta.6",
+    "@scion/toolkit": ">=11.0.0-beta.7",
     "@scion/microfrontend-platform": ">= 1.0.0-beta.11",
     "@scion/workbench-client": ">= 1.0.0-beta.2",
     "rxjs": "^6.0.0"

--- a/projects/scion/workbench/src/lib/microfrontend-platform/routing/microfrontend-navigate-command-handler.service.ts
+++ b/projects/scion/workbench/src/lib/microfrontend-platform/routing/microfrontend-navigate-command-handler.service.ts
@@ -8,13 +8,17 @@
  *  SPDX-License-Identifier: EPL-2.0
  */
 
-import { Injectable } from '@angular/core';
-import { MessageClient } from '@scion/microfrontend-platform';
+import { Injectable, OnDestroy } from '@angular/core';
+import { MessageClient, MessageHeaders, ResponseStatusCodes, TopicMessage } from '@scion/microfrontend-platform';
 import { WorkbenchNavigationExtras, WorkbenchViewCapability, ɵWorkbenchCommands, ɵWorkbenchRouterNavigateCommand } from '@scion/workbench-client';
 import { WorkbenchRouter } from '../../routing/workbench-router.service';
-import { Params } from '@angular/router';
+import { Params, Router } from '@angular/router';
 import { Logger, LoggerNames } from '../../logging';
 import { MicrofrontendViewRoutes } from './microfrontend-routes';
+import { Arrays, Dictionaries, Dictionary } from '@scion/toolkit/util';
+import { Subject } from 'rxjs';
+import { catchError, takeUntil } from 'rxjs/operators';
+import { serializeExecution } from '../../operators';
 
 /**
  * Handles microfrontend navigate commands, instructing the Workbench Router to navigate to the microfrontend of given view capabilities.
@@ -22,36 +26,81 @@ import { MicrofrontendViewRoutes } from './microfrontend-routes';
  * This class is constructed before the Microfrontend Platform activates micro applications via {@link POST_MICROFRONTEND_PLATFORM_CONNECT} DI token.
  */
 @Injectable()
-export class MicrofrontendNavigateCommandHandler {
+export class MicrofrontendNavigateCommandHandler implements OnDestroy {
+
+  private _destroy$ = new Subject<void>();
 
   constructor(private _messageClient: MessageClient,
               private _workbenchRouter: WorkbenchRouter,
+              private _router: Router,
               private _logger: Logger) {
-    this._messageClient.onMessage<ɵWorkbenchRouterNavigateCommand, boolean>(ɵWorkbenchCommands.navigate, async ({body: command}) => {
-      this._logger.debug(() => 'Handling microfrontend navigate command', LoggerNames.MICROFRONTEND, command);
+    this._messageClient.observe$<ɵWorkbenchRouterNavigateCommand>(ɵWorkbenchCommands.navigate)
+      .pipe(
+        serializeExecution(request => this.handleNavigateCommand(request)),
+        catchError((error, caught) => {
+          this._logger.error(() => '[NavigateError] Unexpected. Workbench navigation failed: ', LoggerNames.MICROFRONTEND_ROUTING, error);
+          return caught;
+        }),
+        takeUntil(this._destroy$),
+      )
+      .subscribe();
+  }
 
-      // For multiple capabilities, navigate sequentially to avoid resolving to the same view for target 'blank'.
-      for (const viewCapability of command.capabilities) {
-        const success = await this.navigate(viewCapability, command.extras);
+  private async handleNavigateCommand(message: TopicMessage<ɵWorkbenchRouterNavigateCommand>): Promise<void> {
+    const navigateCommand = message.body;
+    const replyTo = message.headers.get(MessageHeaders.ReplyTo);
+
+    // For multiple capabilities, navigate sequentially to avoid resolving to the same view for target 'blank'.
+    try {
+      for (const viewCapability of navigateCommand.capabilities) {
+        const success = await this.navigate(viewCapability, navigateCommand.extras);
         if (!success) {
-          return false;
+          await this._messageClient.publish(replyTo, false, {headers: new Map().set(MessageHeaders.Status, ResponseStatusCodes.TERMINAL)});
+          return;
         }
       }
-      return true;
+      await this._messageClient.publish(replyTo, true, {headers: new Map().set(MessageHeaders.Status, ResponseStatusCodes.TERMINAL)});
+    }
+    catch (error) {
+      this._logger.error(() => '[NavigateError] Unexpected. Workbench navigation failed: ', LoggerNames.MICROFRONTEND_ROUTING, error);
+      await this._messageClient.publish(replyTo, stringifyError(error), {headers: new Map().set(MessageHeaders.Status, ResponseStatusCodes.ERROR)});
+    }
+  }
+
+  private navigate(viewCapability: WorkbenchViewCapability, extras: WorkbenchNavigationExtras): Promise<boolean> {
+    const matrixParams = this.computeMatrixParams(extras);
+    const routerNavigateCommand = this.buildRouterNavigateCommand(viewCapability.metadata.id, matrixParams);
+
+    this._logger.debug(() => `Navigating to: ${viewCapability.properties.path}`, LoggerNames.MICROFRONTEND_ROUTING, routerNavigateCommand, viewCapability);
+
+    return this._workbenchRouter.navigate(routerNavigateCommand, {
+      activateIfPresent: extras.activateIfPresent,
+      closeIfPresent: extras.closeIfPresent,
+      target: extras.target,
+      blankInsertionIndex: extras.blankInsertionIndex,
+      selfViewId: extras.selfViewId,
     });
   }
 
-  private navigate(viewCapability: WorkbenchViewCapability, navigationExtras: WorkbenchNavigationExtras): Promise<boolean> {
-    const routerNavigateCommand = this.buildRouterNavigateCommand(viewCapability.metadata.id, navigationExtras.params);
-    this._logger.debug(() => 'Navigating to the microfrontend of a view capability', LoggerNames.MICROFRONTEND_ROUTING, routerNavigateCommand, viewCapability);
+  /**
+   * Computes matrix parameters according to the defined `paramsHandling` strategy.
+   * Parameters with the value `undefined` are ignored.
+   */
+  private computeMatrixParams(extras: WorkbenchNavigationExtras): Dictionary {
+    const params = Dictionaries.coerce(extras.params);
 
-    return this._workbenchRouter.navigate(routerNavigateCommand, {
-      activateIfPresent: navigationExtras.activateIfPresent,
-      closeIfPresent: navigationExtras.closeIfPresent,
-      target: navigationExtras.target,
-      blankInsertionIndex: navigationExtras.blankInsertionIndex,
-      selfViewId: navigationExtras.selfViewId,
-    });
+    if (extras.paramsHandling === 'merge' && extras.target === 'self' && extras.selfViewId) {
+      const currentViewUrlSegments = this._router.parseUrl(this._router.url).root.children[extras.selfViewId].segments;
+      const currentMatrixParams = Arrays.last(currentViewUrlSegments).parameters;
+      const mergedMatrixParams = {
+        ...currentMatrixParams,
+        ...params, // new params have precedence over params contained in the URL
+      };
+
+      return withoutUndefinedEntries(mergedMatrixParams);
+    }
+
+    return withoutUndefinedEntries(params);
   }
 
   /**
@@ -63,4 +112,27 @@ export class MicrofrontendNavigateCommandHandler {
     const matrixParamCommand = Object.keys(matrixParams).length > 0 ? [matrixParams] : [];
     return ([MicrofrontendViewRoutes.ROUTE_PREFIX, viewCapabilityId] as any[]).concat(matrixParamCommand);
   }
+
+  public ngOnDestroy(): void {
+    this._destroy$.next();
+  }
+}
+
+function stringifyError(error: any): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return error?.toString();
+}
+
+/**
+ * Returns a new dictionary with `undefined` values removed.
+ */
+function withoutUndefinedEntries(object: Dictionary): Dictionary {
+  return Object.entries(object).reduce((dictionary, [key, value]) => {
+    if (value !== undefined) {
+      dictionary[key] = value;
+    }
+    return dictionary;
+  }, {});
 }

--- a/projects/scion/workbench/src/lib/operators.ts
+++ b/projects/scion/workbench/src/lib/operators.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018-2019 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ */
+
+import { Observable, OperatorFunction } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+
+/**
+ * Serializes the execution of elements emitted by the source Observable.
+ *
+ * For each element emitted by the source, the specified callback function is called.
+ * The next element will only be processed once the Promise or Observable returned by
+ * the callback function resolves or completes.
+ */
+export function serializeExecution<IN, OUT>(fn: (value: IN) => Observable<OUT> | Promise<OUT>): OperatorFunction<IN, OUT> {
+  return mergeMap(element => fn(element), 1);
+}


### PR DESCRIPTION
Self-navigation allows a view to update its parameters in the workbench URL to support persistent navigation.
Setting a `paramsHandling` strategy allows instructing the router how to handle parameters during self-navigation,
i.e., whether to replace or merge params contained in the URL.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, updating dependencies, removal of deprecations, etc)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #259 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
