### PR TITLE
fix(workbench): reset part action list styling

### DIFF
--- a/projects/scion/workbench/src/lib/part/part-action-bar/part-action-bar.component.scss
+++ b/projects/scion/workbench/src/lib/part/part-action-bar/part-action-bar.component.scss
@@ -4,6 +4,7 @@
 
   > ul {
     all: unset;
+    list-style: none;
     flex: auto;
     display: flex;
     gap: .5em;
@@ -20,6 +21,7 @@
     }
 
     > li {
+      all: unset;
       flex: none;
     }
   }

--- a/projects/scion/workbench/src/lib/part/view-list/view-list.component.scss
+++ b/projects/scion/workbench/src/lib/part/view-list/view-list.component.scss
@@ -23,14 +23,18 @@
     max-height: 350px;
 
     > ul {
+      all: unset;
+      list-style: none;
       display: flex;
       flex-direction: column;
-      list-style: none;
-      padding: 1px 0 0 0;
-      margin: 0;
+      padding-top: 1px;
 
-      > li.separator {
-        border-top: 1px solid colors.$viewlistitem-border-color;
+      > li {
+        all: unset;
+
+        &.separator {
+          border-top: 1px solid colors.$viewlistitem-border-color;
+        }
       }
     }
   }


### PR DESCRIPTION
Commit 10b5f6a1 does not fully reset the default list styling.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe: