### PR TITLE
fix(workbench): support application URL to contain view outlets of perspectival views

### DIFF
--- a/projects/scion/e2e-testing/src/app.po.ts
+++ b/projects/scion/e2e-testing/src/app.po.ts
@@ -61,7 +61,19 @@ export class AppPO {
       featureQueryParams.append('showNewTabAction', `${options.showNewTabAction}`);
     }
 
-    await this.page.goto(`${options?.url ?? ''}/?${this._workbenchStartupQueryParams.toString()}#/${featureQueryParams.toString() ? `?${featureQueryParams.toString()}` : ''}`);
+    // Perform navigation.
+    await this.page.goto((() => {
+      const [baseUrl = '/', hashedUrl = ''] = (options?.url?.split('#') ?? []);
+
+      // Add startup query params to the base URL part.
+      const url = `${baseUrl}?${this._workbenchStartupQueryParams.toString()}#${hashedUrl}`;
+      if (!featureQueryParams.size) {
+        return url;
+      }
+      // Add feature query params to the hashed URL part.
+      return hashedUrl.includes('?') ? `${url}&${featureQueryParams}` : `${url}?${featureQueryParams}`;
+    })());
+
     // Wait until the workbench completed startup.
     await this.waitUntilWorkbenchStarted();
   }

--- a/projects/scion/e2e-testing/src/workbench/page-object/view-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench/page-object/view-page.po.ts
@@ -23,38 +23,37 @@ import {SciKeyValuePO} from '../../@scion/components.internal/key-value.po';
  */
 export class ViewPagePO {
 
-  private readonly _locator: Locator;
-
+  public readonly locator: Locator;
   public readonly viewPO: ViewPO;
   public readonly viewTabPO: ViewTabPO;
 
   constructor(appPO: AppPO, public viewId: string) {
     this.viewPO = appPO.view({viewId});
     this.viewTabPO = appPO.view({viewId}).viewTab;
-    this._locator = this.viewPO.locator('app-view-page');
+    this.locator = this.viewPO.locator('app-view-page');
   }
 
   public async isPresent(): Promise<boolean> {
-    return await this.viewTabPO.isPresent() && await isPresent(this._locator);
+    return await this.viewTabPO.isPresent() && await isPresent(this.locator);
   }
 
   public async isVisible(): Promise<boolean> {
-    return await this.viewPO.isVisible() && await this._locator.isVisible();
+    return await this.viewPO.isVisible() && await this.locator.isVisible();
   }
 
   public async getViewId(): Promise<string> {
-    return this._locator.locator('span.e2e-view-id').innerText();
+    return this.locator.locator('span.e2e-view-id').innerText();
   }
 
   public async getComponentInstanceId(): Promise<string> {
-    return this._locator.locator('span.e2e-component-instance-id').innerText();
+    return this.locator.locator('span.e2e-component-instance-id').innerText();
   }
 
   public async getRouteParams(): Promise<Params> {
-    const accordionPO = new SciAccordionPO(this._locator.locator('sci-accordion.e2e-route-params'));
+    const accordionPO = new SciAccordionPO(this.locator.locator('sci-accordion.e2e-route-params'));
     await accordionPO.expand();
     try {
-      return await new SciKeyValuePO(this._locator.locator('sci-key-value.e2e-route-params')).readEntries();
+      return await new SciKeyValuePO(this.locator.locator('sci-key-value.e2e-route-params')).readEntries();
     }
     finally {
       await accordionPO.collapse();
@@ -62,32 +61,32 @@ export class ViewPagePO {
   }
 
   public async enterTitle(title: string): Promise<void> {
-    await this._locator.locator('input.e2e-title').fill(title);
+    await this.locator.locator('input.e2e-title').fill(title);
   }
 
   public async enterHeading(heading: string): Promise<void> {
-    await this._locator.locator('input.e2e-heading').fill(heading);
+    await this.locator.locator('input.e2e-heading').fill(heading);
   }
 
   public async checkDirty(check: boolean): Promise<void> {
-    await new SciCheckboxPO(this._locator.locator('sci-checkbox.e2e-dirty')).toggle(check);
+    await new SciCheckboxPO(this.locator.locator('sci-checkbox.e2e-dirty')).toggle(check);
   }
 
   public async checkClosable(check: boolean): Promise<void> {
-    await new SciCheckboxPO(this._locator.locator('sci-checkbox.e2e-closable')).toggle(check);
+    await new SciCheckboxPO(this.locator.locator('sci-checkbox.e2e-closable')).toggle(check);
   }
 
   public async clickClose(): Promise<void> {
-    const accordionPO = new SciAccordionPO(this._locator.locator('sci-accordion.e2e-view-actions'));
+    const accordionPO = new SciAccordionPO(this.locator.locator('sci-accordion.e2e-view-actions'));
     await accordionPO.expand();
-    await this._locator.locator('button.e2e-close').click();
+    await this.locator.locator('button.e2e-close').click();
   }
 
   public async addViewAction(partAction: WorkbenchPartActionDescriptor, options?: {append?: boolean}): Promise<void> {
-    const accordionPO = new SciAccordionPO(this._locator.locator('sci-accordion.e2e-part-actions'));
+    const accordionPO = new SciAccordionPO(this.locator.locator('sci-accordion.e2e-part-actions'));
     await accordionPO.expand();
     try {
-      const inputLocator = this._locator.locator('input.e2e-part-actions');
+      const inputLocator = this.locator.locator('input.e2e-part-actions');
       if (options?.append ?? true) {
         const input = await inputLocator.inputValue() || null;
         const presentActions: WorkbenchPartActionDescriptor[] = coerceArray(input ? JSON.parse(input) : null);
@@ -103,11 +102,11 @@ export class ViewPagePO {
   }
 
   public async enterFreeText(text: string): Promise<void> {
-    await this._locator.locator('input.e2e-free-text').fill(text);
+    await this.locator.locator('input.e2e-free-text').fill(text);
   }
 
   public getFreeText(): Promise<string> {
-    return this._locator.locator('input.e2e-free-text').inputValue();
+    return this.locator.locator('input.e2e-free-text').inputValue();
   }
 }
 

--- a/projects/scion/workbench/src/lib/routing/workbench-popup-differ.ts
+++ b/projects/scion/workbench/src/lib/routing/workbench-popup-differ.ts
@@ -39,18 +39,18 @@ export class WorkbenchPopupDiffer {
  */
 export class WorkbenchPopupDiff {
 
-  public readonly addedPopups = new Array<string>();
-  public readonly removedPopups = new Array<string>();
+  public readonly addedPopupOutlets = new Array<string>();
+  public readonly removedPopupOutlets = new Array<string>();
 
   constructor(changes: IterableChanges<string> | null) {
-    changes?.forEachAddedItem(({item}) => this.addedPopups.push(item));
-    changes?.forEachRemovedItem(({item}) => this.removedPopups.push(item));
+    changes?.forEachAddedItem(({item}) => this.addedPopupOutlets.push(item));
+    changes?.forEachRemovedItem(({item}) => this.removedPopupOutlets.push(item));
   }
 
   public toString(): string {
     return `${new Array<string>()
-      .concat(this.addedPopups.length ? `addedPopups=[${this.addedPopups}]` : [])
-      .concat(this.removedPopups.length ? `removedPopups=[${this.removedPopups}]` : [])
+      .concat(this.addedPopupOutlets.length ? `addedPopupOutlets=[${this.addedPopupOutlets}]` : [])
+      .concat(this.removedPopupOutlets.length ? `removedPopupOutlets=[${this.removedPopupOutlets}]` : [])
       .join(', ')}`;
   }
 }


### PR DESCRIPTION
Previously, opening the application with a URL containing view outlets of perspectival views caused the Angular error `NG04002` because the perspective layout was unavailable during initial navigation. Now we register routes based on the view outlet in the URL, not the views in the layout.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #474 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
