### PR TITLE
fix(workbench): do not render divider preceding tab dragged out of its tabbar

### DIFF
--- a/projects/scion/workbench/src/lib/part/part-bar/part-bar.component.scss
+++ b/projects/scion/workbench/src/lib/part/part-bar/part-bar.component.scss
@@ -79,8 +79,13 @@
       display: none;
     }
 
-    // Do not render divider preceding the active tab, but only if not the drag source.
+    // Do not render divider preceding the active tab
     > div.divider:has(+ wb-view-tab.active:not(.drag-source)) {
+      display: none;
+    }
+
+    // Do not render divider preceding the tab being dragged out of its tabbar
+    > div.divider:has(+ wb-view-tab.drag-source:not(.active)) {
       display: none;
     }
   }


### PR DESCRIPTION
Dragging a tab out of its tabbar will activate the next tab. No divider should be displayed in front of the newly active tab.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
