### PR TITLE
Issue/routing

### DIFF
--- a/apps/workbench-testing-app/src/app/app.component.ts
+++ b/apps/workbench-testing-app/src/app/app.component.ts
@@ -14,7 +14,7 @@ import {NavigationCancel, NavigationEnd, NavigationError, Router, RouterOutlet} 
 import {UUID} from '@scion/toolkit/uuid';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {AsyncPipe, DOCUMENT, NgIf} from '@angular/common';
-import {WorkbenchStartup} from '@scion/workbench';
+import {WORKBENCH_ID, WorkbenchStartup, WorkbenchViewMenuItemDirective} from '@scion/workbench';
 import {HeaderComponent} from './header/header.component';
 import {fromEvent} from 'rxjs';
 import {subscribeInside} from '@scion/toolkit/operators';
@@ -29,9 +29,13 @@ import {subscribeInside} from '@scion/toolkit/operators';
     AsyncPipe,
     RouterOutlet,
     HeaderComponent,
+    WorkbenchViewMenuItemDirective,
   ],
 })
 export class AppComponent {
+
+  @HostBinding('attr.data-workbench-id')
+  public workbenchId = inject(WORKBENCH_ID);
 
   /**
    * Unique id that is set after a navigation has been performed.

--- a/apps/workbench-testing-app/src/app/test-pages/view-move-dialog-test-page/view-move-dialog-test-page.component.html
+++ b/apps/workbench-testing-app/src/app/test-pages/view-move-dialog-test-page/view-move-dialog-test-page.component.html
@@ -1,0 +1,37 @@
+<form autocomplete="off" [formGroup]="form">
+  <!-- Workbench ID -->
+  <sci-form-field label="Workbench ID" direction="column">
+    <input [formControl]="form.controls.workbenchId" class="e2e-workbench-id" list="target">
+    <datalist id="target">
+      <option value="new-window">new-window</option>
+    </datalist>
+  </sci-form-field>
+
+  @if (form.controls.workbenchId.value !== 'new-window') {
+    <!-- Part ID -->
+    <sci-form-field label="Part ID" direction="column">
+      <input [formControl]="form.controls.partId" class="e2e-part-id">
+    </sci-form-field>
+
+    <!-- Region -->
+    <sci-form-field label="Region" direction="column">
+      <select [formControl]="form.controls.region" class="e2e-region">
+        <option value="east">east</option>
+        <option value="west">west</option>
+        <option value="north">north</option>
+        <option value="south">south</option>
+        <option value=""></option>
+      </select>
+    </sci-form-field>
+  }
+</form>
+
+<!-- OK button -->
+<ng-template wbDialogAction>
+  <button (click)="onOk()" [disabled]="form.invalid" class="e2e-ok">OK</button>
+</ng-template>
+
+<!-- Cancel button -->
+<ng-template wbDialogAction>
+  <button (click)="onCancel()">Cancel</button>
+</ng-template>

--- a/apps/workbench-testing-app/src/app/test-pages/view-move-dialog-test-page/view-move-dialog-test-page.component.scss
+++ b/apps/workbench-testing-app/src/app/test-pages/view-move-dialog-test-page/view-move-dialog-test-page.component.scss
@@ -1,0 +1,10 @@
+:host {
+  display: grid;
+  min-width: 300px;
+
+  > form {
+    display: flex;
+    flex-direction: column;
+    gap: .5em;
+  }
+}

--- a/apps/workbench-testing-app/src/app/test-pages/view-move-dialog-test-page/view-move-dialog-test-page.component.ts
+++ b/apps/workbench-testing-app/src/app/test-pages/view-move-dialog-test-page/view-move-dialog-test-page.component.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018-2024 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {Component, inject, Input} from '@angular/core';
+import {NonNullableFormBuilder, ReactiveFormsModule, Validators} from '@angular/forms';
+import {SciFormFieldComponent} from '@scion/components.internal/form-field';
+import {WORKBENCH_ID, WorkbenchDialog, WorkbenchDialogActionDirective, WorkbenchView} from '@scion/workbench';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+
+@Component({
+  selector: 'app-view-move-dialog-test-page',
+  templateUrl: './view-move-dialog-test-page.component.html',
+  styleUrls: ['./view-move-dialog-test-page.component.scss'],
+  standalone: true,
+  imports: [
+    SciFormFieldComponent,
+    ReactiveFormsModule,
+    WorkbenchDialogActionDirective,
+  ],
+})
+export class ViewMoveDialogTestPageComponent {
+
+  @Input({required: true})
+  public view!: WorkbenchView;
+
+  public form = this._formBuilder.group({
+    workbenchId: this._formBuilder.control<string | 'new-window'>(inject(WORKBENCH_ID)),
+    partId: this._formBuilder.control('', Validators.required),
+    region: this._formBuilder.control<'north' | 'south' | 'west' | 'east' | ''>(''),
+  });
+
+  constructor(private _formBuilder: NonNullableFormBuilder, private _dialog: WorkbenchDialog) {
+    this._dialog.title = 'Move view';
+    this.requirePartIfMovingToPart();
+  }
+
+  public onOk(): void {
+    if (this.form.controls.workbenchId.value === 'new-window') {
+      this.view.move('new-window');
+    }
+    else {
+      this.view.move(this.form.controls.partId.value, {
+        region: this.form.controls.region.value || undefined,
+        workbenchId: this.form.controls.workbenchId.value || undefined,
+      });
+    }
+    this._dialog.close();
+  }
+
+  public onCancel(): void {
+    this._dialog.close();
+  }
+
+  /**
+   * Makes the part a required field if not moving the view to a new window.
+   */
+  private requirePartIfMovingToPart(): void {
+    this.form.controls.workbenchId.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe(target => {
+        if (target === 'new-window') {
+          this.form.controls.partId.removeValidators(Validators.required);
+        }
+        else {
+          this.form.controls.partId.addValidators(Validators.required);
+        }
+        this.form.controls.partId.updateValueAndValidity();
+      });
+  }
+}

--- a/apps/workbench-testing-app/src/app/workbench/workbench.component.html
+++ b/apps/workbench-testing-app/src/app/workbench/workbench.component.html
@@ -4,4 +4,8 @@
       add
     </button>
   </ng-template>
+
+  <ng-template wbViewMenuItem group="move" cssClass="e2e-move-view" (action)="onMoveView($event)">
+    Move view...
+  </ng-template>
 </wb-workbench>

--- a/apps/workbench-testing-app/src/app/workbench/workbench.component.ts
+++ b/apps/workbench-testing-app/src/app/workbench/workbench.component.ts
@@ -15,8 +15,9 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {combineLatest} from 'rxjs';
 import {AsyncPipe, NgIf} from '@angular/common';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {WorkbenchModule, WorkbenchPart, WorkbenchRouter, WorkbenchService} from '@scion/workbench';
+import {WorkbenchDialogService, WorkbenchModule, WorkbenchPart, WorkbenchRouter, WorkbenchService, WorkbenchView} from '@scion/workbench';
 import {SciMaterialIconDirective} from '@scion/components.internal/material-icon';
+import {ViewMoveDialogTestPageComponent} from '../test-pages/view-move-dialog-test-page/view-move-dialog-test-page.component';
 
 @Component({
   selector: 'app-workbench',
@@ -34,6 +35,7 @@ export class WorkbenchComponent implements OnDestroy {
 
   constructor(private _route: ActivatedRoute,
               private _wbRouter: WorkbenchRouter,
+              private _dialogService: WorkbenchDialogService,
               protected workbenchService: WorkbenchService) {
     console.debug('[WorkbenchComponent#construct]');
     this.installStickyStartViewTab();
@@ -45,6 +47,14 @@ export class WorkbenchComponent implements OnDestroy {
   protected isPartInMainArea = (part: WorkbenchPart): boolean => {
     return part.isInMainArea;
   };
+
+  protected onMoveView(view: WorkbenchView): void {
+    this._dialogService.open(ViewMoveDialogTestPageComponent, {
+      inputs: {view},
+      cssClass: 'e2e-move-view',
+      context: {viewId: view.id},
+    });
+  }
 
   /**
    * If enabled, installs the handler to automatically open the start tab when the user closes the last tab.

--- a/projects/scion/e2e-testing/src/app.po.ts
+++ b/projects/scion/e2e-testing/src/app.po.ts
@@ -31,7 +31,7 @@ export class AppPO {
   /**
    * Locates the 'wb-workbench' element.
    */
-  public readonly workbenchLocator = this.page.locator('wb-workbench');
+  public readonly workbench = this.page.locator('wb-workbench');
 
   /**
    * Locates workbench notifications.
@@ -196,7 +196,7 @@ export class AppPO {
    * Returns bounding box of the 'wb-workbench' element.
    */
   public async workbenchBoundingBox(): Promise<DomRect> {
-    return fromRect(await this.workbenchLocator.boundingBox());
+    return fromRect(await this.workbench.boundingBox());
   }
 
   /**
@@ -305,7 +305,7 @@ export class AppPO {
    */
   public async setDesignToken(name: string, value: string): Promise<void> {
     const pageFunction = (workbenchElement: HTMLElement, token: {name: string; value: string}): void => workbenchElement.style.setProperty(token.name, token.value);
-    await this.workbenchLocator.evaluate(pageFunction, {name, value});
+    await this.workbench.evaluate(pageFunction, {name, value});
   }
 }
 

--- a/projects/scion/e2e-testing/src/app.po.ts
+++ b/projects/scion/e2e-testing/src/app.po.ts
@@ -269,8 +269,17 @@ export class AppPO {
    *
    * This flag is set in `app.component.ts` in the 'workbench-testing-app'.
    */
-  public getCurrentNavigationId(): Promise<string | null> {
-    return this.page.locator('app-root').getAttribute('data-navigationid');
+  public getCurrentNavigationId(): Promise<string | undefined> {
+    return this.page.locator('app-root').getAttribute('data-navigationid').then(value => value ?? undefined);
+  }
+
+  /**
+   * Returns the unique id of this workbench.
+   *
+   * @see WORKBENCH_ID
+   */
+  public getWorkbenchIdId(): Promise<string | undefined> {
+    return this.page.locator('app-root').getAttribute('data-workbench-id').then(value => value ?? undefined);
   }
 
   /**
@@ -289,26 +298,6 @@ export class AppPO {
     const dropZoneCssClass = target.grid === 'mainArea' ? 'e2e-main-area-grid' : 'e2e-workbench-grid';
     const dropZoneLocator = this.page.locator(`div.e2e-view-drop-zone.e2e-${target.region}.${dropZoneCssClass}`);
     return fromRect(await dropZoneLocator.boundingBox());
-  }
-
-  /**
-   * Waits for the specified window to open; must be invoked prior to opening the window.
-   *
-   * Example:
-   *
-   * ```ts
-   * const [newAppPO] = await Promise.all([
-   *   appPO.waitForWindow(async page => (await getPerspectiveName(page)) === 'testee'),
-   *   buttonPO.openInNewWindow(),
-   * ]);
-   * ```
-   */
-  public async waitForWindow(predicate: (page: Page) => Promise<boolean>): Promise<AppPO> {
-    const page = await this.page.waitForEvent('popup', {predicate});
-    const newAppPO = new AppPO(page);
-    // Wait until the workbench completed startup.
-    await newAppPO.waitUntilWorkbenchStarted();
-    return newAppPO;
   }
 
   /**

--- a/projects/scion/e2e-testing/src/app.po.ts
+++ b/projects/scion/e2e-testing/src/app.po.ts
@@ -219,7 +219,7 @@ export class AppPO {
    * Handle to the specified message box.
    */
   public messagebox(locateBy?: {cssClass?: string | string[]; nth?: number}): MessageBoxPO {
-    return new MessageBoxPO(this.dialog(locateBy), this.page);
+    return new MessageBoxPO(this.dialog(locateBy));
   }
 
   /**
@@ -228,7 +228,7 @@ export class AppPO {
   public dialog(locateBy?: {cssClass?: string | string[]; nth?: number}): DialogPO {
     const cssClasses = coerceArray(locateBy?.cssClass).map(cssClass => cssClass.replace(/\./g, '\\.'));
     const locator = this.page.locator(['wb-dialog'].concat(cssClasses).join('.'));
-    return new DialogPO(this, locateBy?.nth !== undefined ? locator.nth(locateBy.nth) : locator);
+    return new DialogPO(locateBy?.nth !== undefined ? locator.nth(locateBy.nth) : locator);
   }
 
   /**

--- a/projects/scion/e2e-testing/src/dialog.po.ts
+++ b/projects/scion/e2e-testing/src/dialog.po.ts
@@ -30,7 +30,7 @@ export class DialogPO {
     horizontal: Locator;
   };
 
-  constructor(private _appPO: AppPO, public readonly locator: Locator) {
+  constructor(public readonly locator: Locator) {
     this._dialog = this.locator.locator('div.e2e-dialog');
     this.header = this._dialog.locator('header.e2e-dialog-header');
     this.title = this.header.locator('div.e2e-title > span');
@@ -80,7 +80,7 @@ export class DialogPO {
 
   public async moveDialog(distance: {x: number; y: number} | 'top-left-corner' | 'top-right-corner' | 'bottom-right-corner' | 'bottom-left-corner'): Promise<void> {
     const dialogBoundingBox = await this.getDialogBoundingBox();
-    const viewportBoundingBox = this._appPO.viewportBoundingBox();
+    const viewportBoundingBox = new AppPO(this.locator.page()).viewportBoundingBox();
 
     switch (distance) {
       case 'top-left-corner': {

--- a/projects/scion/e2e-testing/src/matcher/to-equal-workbench-layout.matcher.ts
+++ b/projects/scion/e2e-testing/src/matcher/to-equal-workbench-layout.matcher.ts
@@ -63,7 +63,7 @@ async function assertWorkbenchLayout(expected: ExpectedWorkbenchLayout, locator:
  * @see assertPartGridElement
  */
 async function assertGridElement(expectedGridElement: MTreeNode | MPart, gridElementLocator: Locator, expectedWorkbenchLayout: ExpectedWorkbenchLayout): Promise<void> {
-  await throwIfAbsent(gridElementLocator, () => Error(`[DOMAssertError] Expected grid element to be present, but is not'. [${expectedGridElement.type}=${JSON.stringify(expectedGridElement)}, locator=${gridElementLocator}]`));
+  await throwIfAbsent(gridElementLocator, () => Error(`[DOMAssertError] Expected grid element to be present, but is not. [${expectedGridElement.type}=${JSON.stringify(expectedGridElement)}, locator=${gridElementLocator}]`));
 
   if (expectedGridElement instanceof MTreeNode) {
     await assertNodeGridElement(expectedGridElement, gridElementLocator, expectedWorkbenchLayout);
@@ -154,7 +154,7 @@ async function assertPartGridElement(expectedPart: MPart, gridElementLocator: Lo
   if (expectedPart.views) {
     const expectedViewIds = expectedPart.views.map(view => view.id);
     const actualViewIds = new Array<string>();
-    for (const viewTabLocator of await partLocator.locator('wb-part-bar wb-view-tab').all()) {
+    for (const viewTabLocator of await partLocator.locator('wb-part-bar wb-view-tab:not(.drag-source)').all()) {
       actualViewIds.push((await viewTabLocator.getAttribute('data-viewid'))!);
     }
     if (!isEqualArray(actualViewIds, expectedViewIds)) {

--- a/projects/scion/e2e-testing/src/message-box.po.ts
+++ b/projects/scion/e2e-testing/src/message-box.po.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator} from '@playwright/test';
 import {DialogPO} from './dialog.po';
 import {DomRect, fromRect} from './helper/testing.util';
 
@@ -24,7 +24,7 @@ export class MessageBoxPO {
   private readonly _header: Locator;
   private readonly _footer: Locator;
 
-  constructor(private _dialog: DialogPO, private _page: Page) {
+  constructor(private _dialog: DialogPO) {
     this.locator = this._dialog.locator.locator('wb-message-box');
     this._header = this._dialog.header.locator('wb-message-box-header');
     this._footer = this._dialog.footer.locator('wb-message-box-footer');

--- a/projects/scion/e2e-testing/src/start-page.po.ts
+++ b/projects/scion/e2e-testing/src/start-page.po.ts
@@ -32,7 +32,7 @@ export class StartPagePO implements WorkbenchViewPagePO {
       this.locator = this._view.locator.locator('app-start-page');
     }
     else {
-      this.locator = this._appPO.workbenchLocator.locator('app-start-page');
+      this.locator = this._appPO.workbench.locator('app-start-page');
     }
     this._tabbarLocator = this.locator.locator('sci-tabbar');
     this._tabbar = new SciTabbarPO(this._tabbarLocator);

--- a/projects/scion/e2e-testing/src/view-tab-context-menu.po.ts
+++ b/projects/scion/e2e-testing/src/view-tab-context-menu.po.ts
@@ -19,6 +19,7 @@ export class ViewTabContextMenuPO {
     closeTab: new ContextMenuItem(this.locator.locator('button.e2e-close-tab')),
     closeAll: new ContextMenuItem(this.locator.locator('button.e2e-close-all-tabs')),
     moveToNewWindow: new ContextMenuItem(this.locator.locator('button.e2e-move-to-new-window')),
+    moveView: new ContextMenuItem(this.locator.locator('button.e2e-move-view')),
   };
 
   constructor(public locator: Locator) {

--- a/projects/scion/e2e-testing/src/workbench-client/contextual-view.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/contextual-view.e2e-spec.ts
@@ -36,7 +36,7 @@ test.describe('Contextual Workbench View', () => {
     await popupOpenerView.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
 
@@ -76,7 +76,7 @@ test.describe('Contextual Workbench View', () => {
     await popupOpenerView.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
 

--- a/projects/scion/e2e-testing/src/workbench-client/page-object/popup-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/page-object/popup-page.po.ts
@@ -9,7 +9,6 @@
  */
 
 import {withoutUndefinedEntries} from '../../helper/testing.util';
-import {AppPO} from '../../app.po';
 import {PopupPO} from '../../popup.po';
 import {PopupSize} from '@scion/workbench';
 import {Params} from '@angular/router';
@@ -19,6 +18,7 @@ import {Locator} from '@playwright/test';
 import {SciKeyValuePO} from '../../@scion/components.internal/key-value.po';
 import {SciRouterOutletPO} from './sci-router-outlet.po';
 import {MicrofrontendPopupPagePO} from '../../workbench/page-object/workbench-popup-page.po';
+import {AppPO} from '../../app.po';
 
 /**
  * Page object to interact with {@link PopupPageComponent}.
@@ -29,8 +29,8 @@ export class PopupPagePO implements MicrofrontendPopupPagePO {
   public readonly outlet: SciRouterOutletPO;
   private readonly _hasFocusLocator: Locator;
 
-  constructor(appPO: AppPO, public popup: PopupPO) {
-    this.outlet = new SciRouterOutletPO(appPO, {locator: popup.locator.locator('sci-router-outlet')});
+  constructor(public popup: PopupPO) {
+    this.outlet = new SciRouterOutletPO(new AppPO(popup.locator.page()), {locator: popup.locator.locator('sci-router-outlet')});
     this.locator = this.outlet.frameLocator.locator('app-popup-page');
     this._hasFocusLocator = this.outlet.frameLocator.locator('app-root').locator('.e2e-has-focus');
   }

--- a/projects/scion/e2e-testing/src/workbench-client/page-object/test-pages/microfrontend-popup-test-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/page-object/test-pages/microfrontend-popup-test-page.po.ts
@@ -19,8 +19,8 @@ export class MicrofrontendPopupTestPagePO implements MicrofrontendPopupPagePO {
   public readonly locator: Locator;
   public readonly outlet: SciRouterOutletPO;
 
-  constructor(appPO: AppPO, public popup: PopupPO) {
-    this.outlet = new SciRouterOutletPO(appPO, {locator: this.popup.locator.locator('sci-router-outlet')});
+  constructor(public popup: PopupPO) {
+    this.outlet = new SciRouterOutletPO(new AppPO(popup.locator.page()), {locator: this.popup.locator.locator('sci-router-outlet')});
     this.locator = this.outlet.frameLocator.locator('app-microfrontend-test-page');
   }
 }

--- a/projects/scion/e2e-testing/src/workbench-client/part.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/part.e2e-spec.ts
@@ -33,7 +33,7 @@ test.describe('Workbench Part', () => {
     const rightViewId = await rightTestPage.view.getViewId();
 
     // Expect right part to be activated.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       mainAreaGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -57,7 +57,7 @@ test.describe('Workbench Part', () => {
     await leftTestPage.clickInputField();
 
     // Expect left part to be activated.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       mainAreaGrid: {
         root: new MTreeNode({
           direction: 'row',

--- a/projects/scion/e2e-testing/src/workbench-client/popup-capability.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/popup-capability.e2e-spec.ts
@@ -33,7 +33,7 @@ test.describe('Workbench Popup Capability', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect the popup of this app to display
     await expect.poll(() => popupPage.getPopupCapability()).toEqual(expect.objectContaining({

--- a/projects/scion/e2e-testing/src/workbench-client/popup-params.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/popup-params.e2e-spec.ts
@@ -37,7 +37,7 @@ test.describe('Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect qualifier to be contained in popup params
     await expect.poll(() => popupPage.getPopupParams()).toEqual(expect.objectContaining({entity: 'product', id: '123'}));
@@ -61,7 +61,7 @@ test.describe('Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect qualifier to be contained in popup params
     await expect.poll(() => popupPage.getPopupParams()).toEqual(expect.objectContaining({entity: 'products'}));
@@ -89,7 +89,7 @@ test.describe('Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect qualifier values not to be overwritten by params
     await expect.poll(() => popupPage.getPopupParams()).toEqual(expect.objectContaining({entity: 'product', mode: 'new'}));
@@ -120,7 +120,7 @@ test.describe('Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect named params to be substituted
     await expect.poll(() => popupPage.getPopupParams()).toEqual(expect.objectContaining({component: 'testee', seg1: 'SEG1', seg3: 'SEG3', mp1: 'MP1', mp2: 'MP2', qp1: 'QP1', qp2: 'QP2', fragment: 'FRAGMENT'}));

--- a/projects/scion/e2e-testing/src/workbench-client/popup-referrer.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/popup-referrer.e2e-spec.ts
@@ -35,7 +35,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await expect.poll(() => popupPage.getReferrer()).toEqual({
         viewId: await popupOpenerPage.view.getViewId(),
@@ -67,7 +67,7 @@ test.describe('Workbench Popup', () => {
       await startPage.view.tab.click();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await expect.poll(() => popupPage.getReferrer()).toEqual({viewId: startPageViewId});
     });
@@ -96,7 +96,7 @@ test.describe('Workbench Popup', () => {
       await microfrontendPage.view.tab.click();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await expect.poll(() => popupPage.getReferrer()).toEqual({
         viewId: microfrontendViewId,
@@ -122,7 +122,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await expect.poll(() => popupPage.getReferrer()).toEqual({});
     });

--- a/projects/scion/e2e-testing/src/workbench-client/popup-router.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/popup-router.e2e-spec.ts
@@ -36,7 +36,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect popup to display
     await expectPopup(popupPage).toBeVisible();
@@ -61,7 +61,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect popup to display
     await expectPopup(popupPage).toBeVisible();
@@ -90,7 +90,7 @@ test.describe('Popup Router', () => {
     await expect(popupOpenerPage.open()).rejects.toThrow(/NullProviderError/);
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect popup not to display
     await expectPopup(popupPage).not.toBeAttached();
@@ -119,7 +119,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
   });
@@ -144,7 +144,7 @@ test.describe('Popup Router', () => {
     await expect(popupOpenerPage.open()).rejects.toThrow(/NotQualifiedError/);
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect popup not to display
     await expectPopup(popupPage).not.toBeAttached();
@@ -184,7 +184,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage1.open();
 
     const popup1 = appPO.popup({cssClass: 'testee-1'});
-    const popupPage1 = new PopupPagePO(appPO, popup1);
+    const popupPage1 = new PopupPagePO(popup1);
 
     // expect the popup of this app to display
     await expectPopup(popupPage1).toBeVisible();
@@ -199,7 +199,7 @@ test.describe('Popup Router', () => {
 
     // expect popup to display
     const popup2 = appPO.popup({cssClass: 'testee-2'});
-    const popupPage2 = new PopupPagePO(appPO, popup2);
+    const popupPage2 = new PopupPagePO(popup2);
 
     // expect the popup of this app to display
     await expectPopup(popupPage2).toBeVisible();
@@ -214,7 +214,7 @@ test.describe('Popup Router', () => {
 
     // expect popup to display
     const popup3 = appPO.popup({cssClass: 'testee-3'});
-    const popupPage3 = new PopupPagePO(appPO, popup3);
+    const popupPage3 = new PopupPagePO(popup3);
 
     // expect the popup of this app to display
     await expectPopup(popupPage3).toBeVisible();
@@ -239,7 +239,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new MicrofrontendPopupTestPagePO(appPO, popup);
+    const popupPage = new MicrofrontendPopupTestPagePO(popup);
 
     // expect popup to display
     await expectPopup(popupPage).toBeVisible();
@@ -275,7 +275,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect the popup of this app to display
     await expectPopup(popupPage).toBeVisible();
@@ -308,7 +308,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect the popup of this app to display
     await expectPopup(popupPage).toBeVisible();
@@ -345,7 +345,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect first popup to display
     await expectPopup(popupPage).toBeVisible();
@@ -379,7 +379,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // expect first popup to display
     await expectPopup(popupPage).toBeVisible();
@@ -407,7 +407,7 @@ test.describe('Popup Router', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
 

--- a/projects/scion/e2e-testing/src/workbench-client/popup-size.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/popup-size.e2e-spec.ts
@@ -114,7 +114,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await popupPage.enterComponentSize({
       width: '600px',

--- a/projects/scion/e2e-testing/src/workbench-client/popup-splash.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/popup-splash.e2e-spec.ts
@@ -36,7 +36,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // Expect splash to display.
     await expect(popupPage.outlet.splash).toBeVisible();
@@ -70,7 +70,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // Expect splash not to display.
     await expect(popupPage.outlet.splash).not.toBeVisible();
@@ -95,7 +95,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     // Expect splash not to display.
     await expect(popupPage.outlet.splash).not.toBeVisible();

--- a/projects/scion/e2e-testing/src/workbench-client/popup.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/popup.e2e-spec.ts
@@ -40,7 +40,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
     await expect.poll(() => popup.getAlign()).toEqual('north');
@@ -66,7 +66,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
     await expect.poll(() => popup.getAlign()).toEqual('north');
@@ -92,7 +92,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
     await expect.poll(() => popup.getAlign()).toEqual('south');
@@ -118,7 +118,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
     await expect.poll(() => popup.getAlign()).toEqual('east');
@@ -144,7 +144,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await expectPopup(popupPage).toBeVisible();
     await expect.poll(() => popup.getAlign()).toEqual('west');
@@ -168,7 +168,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await popupPage.close({returnValue: 'RETURN VALUE'});
     await expect(popupOpenerPage.returnValue).toHaveText('RETURN VALUE');
@@ -192,7 +192,7 @@ test.describe('Workbench Popup', () => {
     await popupOpenerPage.open();
 
     const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new PopupPagePO(appPO, popup);
+    const popupPage = new PopupPagePO(popup);
 
     await popupPage.close({returnValue: 'ERROR', closeWithError: true});
     await expect(popupOpenerPage.error).toHaveText('ERROR');
@@ -293,7 +293,6 @@ test.describe('Workbench Popup', () => {
     await expect.poll(() => popup.getBoundingBox().then(box => box.top - POPUP_DIAMOND_ANCHOR_SIZE)).toEqual(viewBounds.top + 400);
   });
 
-
   test.describe('view context', () => {
 
     test('should hide the popup when its contextual view (if any) is deactivated, and then display the popup again when activating it', async ({appPO, microfrontendNavigator}) => {
@@ -315,7 +314,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await expectPopup(popupPage).toBeVisible();
 
@@ -347,7 +346,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
       const componentInstanceId = await popupPage.getComponentInstanceId();
 
       await expectPopup(popupPage).toBeVisible();
@@ -383,7 +382,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await expectPopup(popupPage).toBeVisible();
 
@@ -422,7 +421,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await popupPage.waitForFocusIn();
       await popupOpenerPage.view.tab.click();
@@ -448,7 +447,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await popupPage.waitForFocusIn();
       await popupOpenerPage.view.tab.click();
@@ -475,7 +474,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await popupPage.waitForFocusIn();
 
@@ -520,7 +519,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       await popupPage.waitForFocusIn();
 
@@ -557,7 +556,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       // Expect popup to have focus.
       await popupPage.waitForFocusIn();
@@ -597,7 +596,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup = appPO.popup({cssClass: 'testee'});
-      const popupPage = new PopupPagePO(appPO, popup);
+      const popupPage = new PopupPagePO(popup);
 
       // Expect popup to have focus.
       await popupPage.waitForFocusIn();

--- a/projects/scion/e2e-testing/src/workbench/dialog.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/dialog.e2e-spec.ts
@@ -193,7 +193,7 @@ test.describe('Workbench Dialog', () => {
       await expect(dialog1.locator).toBeVisible();
 
       // Open another dialog from the dialog (inherit dialog's view context).
-      const dialogOpenerPage2 = new DialogOpenerPagePO(appPO, dialog1);
+      const dialogOpenerPage2 = new DialogOpenerPagePO(dialog1);
       await dialogOpenerPage2.open('dialog-page', {cssClass: 'testee-2'});
       const dialog2 = appPO.dialog({cssClass: 'testee-2'});
 
@@ -283,7 +283,7 @@ test.describe('Workbench Dialog', () => {
       await expect(applicationModalDialog1.locator).toBeVisible();
       await expect(applicationModalDialog2.locator).toBeVisible();
 
-      const dialogOpenerDialogPage = new DialogOpenerPagePO(appPO, applicationModalDialog2);
+      const dialogOpenerDialogPage = new DialogOpenerPagePO(applicationModalDialog2);
       const contextualViewId = await dialogOpenerViewPage.view.getViewId();
 
       // Open view-modal dialog.
@@ -943,7 +943,7 @@ test.describe('Workbench Dialog', () => {
       const dialogBoundingBox = await dialog.getDialogBoundingBox();
 
       // Block the dialog by opening another dialog.
-      const dialogOpenerDialogPage = new DialogOpenerPagePO(appPO, dialog);
+      const dialogOpenerDialogPage = new DialogOpenerPagePO(dialog);
       await dialogOpenerDialogPage.open('dialog-page', {cssClass: 'top-dialog'});
       const topDialog = appPO.dialog({cssClass: 'top-dialog'});
       await topDialog.moveDialog('bottom-right-corner');
@@ -1992,7 +1992,7 @@ test.describe('Workbench Dialog', () => {
       await dialog1.moveDialog('bottom-left-corner');
 
       // Open dialog 2 from dialog 1.
-      const dialogOpenerDialogPage = new DialogOpenerPagePO(appPO, dialog1);
+      const dialogOpenerDialogPage = new DialogOpenerPagePO(dialog1);
       await dialogOpenerDialogPage.open('focus-test-page', {cssClass: 'testee-2'});
       const dialog2 = appPO.dialog({cssClass: 'testee-2'});
       await dialog2.moveDialog('bottom-right-corner');
@@ -2030,7 +2030,7 @@ test.describe('Workbench Dialog', () => {
       const popup = appPO.popup({cssClass: 'testee'});
 
       // Open dialog from popup.
-      const dialogOpenerPopupPage = new DialogOpenerPagePO(appPO, popup);
+      const dialogOpenerPopupPage = new DialogOpenerPagePO(popup);
       await dialogOpenerPopupPage.open('focus-test-page', {cssClass: 'testee'});
 
       const dialog = appPO.dialog({cssClass: 'testee'});

--- a/projects/scion/e2e-testing/src/workbench/maximize-main-area.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/maximize-main-area.e2e-spec.ts
@@ -68,7 +68,7 @@ test.describe('Workbench', () => {
     const viewId2 = await view2.getViewId();
 
     // Expect the workbench layout.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -99,7 +99,7 @@ test.describe('Workbench', () => {
 
     // Maximize the main area.
     await view2.tab.dblclick();
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -118,7 +118,7 @@ test.describe('Workbench', () => {
 
     // Restore the main area.
     await view2.tab.dblclick();
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',

--- a/projects/scion/e2e-testing/src/workbench/move-view-to-new-window.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/move-view-to-new-window.e2e-spec.ts
@@ -46,7 +46,7 @@ test.describe('Workbench View', () => {
     await newWindowLayoutPage.view.tab.close();
 
     // Expect test view to be moved to the new window.
-    await expect(newAppPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newAppPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -63,7 +63,7 @@ test.describe('Workbench View', () => {
     await expectView(viewPage).toBeActive();
 
     // Expect test view to be removed from the origin window.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -105,7 +105,7 @@ test.describe('Workbench View', () => {
     const newAppPO = await appPO.view({viewId: testViewId}).tab.moveToNewWindow();
 
     // Expect test view to be moved to the new window.
-    await expect(newAppPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newAppPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -122,7 +122,7 @@ test.describe('Workbench View', () => {
     await expectView(viewPage).toBeActive();
 
     // Expect test view to be removed from the origin window.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -166,7 +166,7 @@ test.describe('Workbench View', () => {
     await newWindowLayoutPage.view.tab.close();
 
     // Expect test view to be moved to the new window.
-    await expect(newAppPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newAppPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -183,7 +183,7 @@ test.describe('Workbench View', () => {
     await expectView(viewPage).toBeActive();
 
     // Expect test view to be removed from the origin window.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -215,7 +215,7 @@ test.describe('Workbench View', () => {
     const newAppPO = await testViewPage.tab.moveToNewWindow();
 
     // Expect test view to be moved to the new window.
-    await expect(newAppPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newAppPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -232,7 +232,7 @@ test.describe('Workbench View', () => {
     await expectView(viewPage).toBeActive();
 
     // Expect test view to be removed from the origin window.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -263,7 +263,7 @@ test.describe('Workbench View', () => {
     // Move view 1 to a new window
     const newAppPO = await view1.tab.moveToNewWindow();
     // Expect view 1 to be moved to the new window.
-    await expect(newAppPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newAppPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -277,7 +277,7 @@ test.describe('Workbench View', () => {
       },
     });
     // Expect view 1 to be removed from the original window.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -297,7 +297,7 @@ test.describe('Workbench View', () => {
       workbenchId: await newAppPO.getWorkbenchIdId(),
     });
     // Expect view 2 to be moved to the new window.
-    await expect(newAppPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newAppPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -312,7 +312,7 @@ test.describe('Workbench View', () => {
       },
     });
     // Expect view 2 to be removed from the original window.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -331,7 +331,7 @@ test.describe('Workbench View', () => {
       workbenchId: await newAppPO.getWorkbenchIdId(),
     });
     // Expect view 3 to be moved to the new window.
-    await expect(newAppPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newAppPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -384,7 +384,7 @@ test.describe('Workbench View', () => {
     await peripheralViewPage.tab.dragTo({grid: 'workbench', region: 'east'});
 
     // Expect peripheral view to be dragged to the workbench grid.
-    await expect(newWindow.appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newWindow.appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -422,7 +422,7 @@ test.describe('Workbench View', () => {
     await newWindow.appPO.switchPerspective('test-blank');
 
     // Expect the layout to be blank.
-    await expect(newWindow.appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newWindow.appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },
@@ -438,7 +438,7 @@ test.describe('Workbench View', () => {
     await newWindow.appPO.switchPerspective(anonymousPerspectiveName);
 
     // Expect the layout of the anonymous perspective to be restored.
-    await expect(newWindow.appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newWindow.appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -492,7 +492,7 @@ test.describe('Workbench View', () => {
     await peripheralViewPage.tab.dragTo({grid: 'workbench', region: 'east'});
 
     // Expect peripheral view to be dragged to the workbench grid.
-    await expect(newWindow.appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newWindow.appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -516,7 +516,7 @@ test.describe('Workbench View', () => {
     await newWindow.appPO.reload();
 
     // Expect the layout of the workbench grid not to be restored.
-    await expect(newWindow.appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(newWindow.appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },

--- a/projects/scion/e2e-testing/src/workbench/page-object/dialog-opener-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench/page-object/dialog-opener-page.po.ts
@@ -29,7 +29,7 @@ export class DialogOpenerPagePO implements WorkbenchViewPagePO {
   public readonly error: Locator;
   public readonly openButton: Locator;
 
-  constructor(private _appPO: AppPO, private _locateBy: ViewPO | PopupPO | DialogPO) {
+  constructor(private _locateBy: ViewPO | PopupPO | DialogPO) {
     this.locator = this._locateBy.locator.locator('app-dialog-opener-page');
     this.returnValue = this.locator.locator('output.e2e-return-value');
     this.error = this.locator.locator('output.e2e-dialog-error');
@@ -119,7 +119,7 @@ export class DialogOpenerPagePO implements WorkbenchViewPagePO {
     const cssClasses = coerceArray(options?.cssClass).filter(Boolean);
 
     for (let i = 0; i < (options?.count ?? 1); i++) {
-      const dialog = this._appPO.dialog({cssClass: [`index-${i}`].concat(cssClasses)});
+      const dialog = new AppPO(this.locator.page()).dialog({cssClass: [`index-${i}`].concat(cssClasses)});
       await dialog.locator.waitFor({state: 'attached'});
     }
   }

--- a/projects/scion/e2e-testing/src/workbench/page-object/popup-opener-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench/page-object/popup-opener-page.po.ts
@@ -29,7 +29,7 @@ export class PopupOpenerPagePO implements WorkbenchViewPagePO {
   public readonly error: Locator;
   public readonly openButton: Locator;
 
-  constructor(private _appPO: AppPO, private _locateBy: ViewPO | PopupPO | DialogPO) {
+  constructor(private _locateBy: ViewPO | PopupPO | DialogPO) {
     this.locator = this._locateBy.locator.locator('app-popup-opener-page');
     this.openButton = this.locator.locator('button.e2e-open');
     this.returnValue = this.locator.locator('output.e2e-return-value');
@@ -192,7 +192,7 @@ export class PopupOpenerPagePO implements WorkbenchViewPagePO {
 
   private async waitUntilPopupAttached(): Promise<void> {
     const cssClass = (await this.locator.locator('input.e2e-class').inputValue()).split(/\s+/).filter(Boolean);
-    const popup = this._appPO.popup({cssClass});
+    const popup = new AppPO(this.locator.page()).popup({cssClass});
     await popup.locator.waitFor({state: 'attached'});
   }
 

--- a/projects/scion/e2e-testing/src/workbench/page-object/test-pages/view-move-dialog-test-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench/page-object/test-pages/view-move-dialog-test-page.po.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018-2024 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms from the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {Locator} from '@playwright/test';
+import {WorkbenchDialogPagePO} from '../workbench-dialog-page.po';
+import {DialogPO} from '../../../dialog.po';
+
+/**
+ * Page object to interact with {@link ViewMoveDialogTestPageComponent}.
+ */
+export class ViewMoveDialogTestPagePO implements WorkbenchDialogPagePO {
+
+  public readonly locator: Locator;
+
+  constructor(public dialog: DialogPO) {
+    this.locator = this.dialog.locator.locator('app-view-move-dialog-test-page');
+  }
+
+  public async enterWorkbenchId(workbenchId: string): Promise<void> {
+    await this.locator.locator('input.e2e-workbench-id').fill(workbenchId);
+  }
+
+  public async enterPartId(partId: string): Promise<void> {
+    await this.locator.locator('input.e2e-part-id').fill(partId);
+  }
+
+  public async enterRegion(region: 'north' | 'south' | 'west' | 'east' | ''): Promise<void> {
+    await this.locator.locator('select.e2e-region').selectOption(region);
+  }
+
+  public async pressOK(): Promise<void> {
+    await this.dialog.footer.locator('button.e2e-ok').click();
+  }
+}

--- a/projects/scion/e2e-testing/src/workbench/popup.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/popup.e2e-spec.ts
@@ -580,7 +580,7 @@ test.describe('Workbench Popup', () => {
       await popupOpenerPage.open();
 
       const popup1 = appPO.popup({cssClass: 'testee-1'});
-      const popupPopupOpenerPage1 = new PopupOpenerPagePO(appPO, popup1);
+      const popupPopupOpenerPage1 = new PopupOpenerPagePO(popup1);
 
       await expectPopup(popupPopupOpenerPage1).toBeHidden();
 

--- a/projects/scion/e2e-testing/src/workbench/router-link.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/router-link.e2e-spec.ts
@@ -388,7 +388,7 @@ test.describe('Workbench RouterLink', () => {
     await appPO.switchPerspective('test');
 
     // Expect layout to match the perspective definition.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -411,7 +411,7 @@ test.describe('Workbench RouterLink', () => {
 
     // Expect new view to be opened in active part of the contextual view i.e. left
     const testeeViewId = await testeeViewPage.view.getViewId();
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',

--- a/projects/scion/e2e-testing/src/workbench/router.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/router.e2e-spec.ts
@@ -1107,7 +1107,7 @@ test.describe('Workbench Router', () => {
     await routerPage.clickNavigate();
 
     // Expect the view to be opened in the left part.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -1140,7 +1140,7 @@ test.describe('Workbench Router', () => {
     await appPO.navigateTo({url, microfrontendSupport: false, perspectives: ['perspective']});
 
     // THEN: Expect the workbench layout to be restored.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -1187,7 +1187,7 @@ test.describe('Workbench Router', () => {
     await routerPage.clickNavigate();
 
     // Expect the view to be opened in the left part.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MTreeNode({
           direction: 'row',
@@ -1229,7 +1229,7 @@ test.describe('Workbench Router', () => {
     await routerPage.clickNavigate();
 
     // Expect the view to be opened in the left part.
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({id: MAIN_AREA}),
       },

--- a/projects/scion/e2e-testing/src/workbench/view-drag-main-area-grid.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/view-drag-main-area-grid.e2e-spec.ts
@@ -41,7 +41,7 @@ test.describe('View Drag Main Area', () => {
       await view2.tab.dragTo({grid: 'mainArea', region: 'west'});
 
       // Expect view 2 to be moved to the west of the main area.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MPart({
             id: MAIN_AREA,
@@ -97,7 +97,7 @@ test.describe('View Drag Main Area', () => {
       await view2.tab.dragTo({grid: 'mainArea', region: 'east'});
 
       // Expect view 2 to be moved to the east of the main area.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MPart({
             id: MAIN_AREA,
@@ -153,7 +153,7 @@ test.describe('View Drag Main Area', () => {
       await view2.tab.dragTo({grid: 'mainArea', region: 'south'});
 
       // Expect view 2 to be moved to the south of the main area.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MPart({
             id: MAIN_AREA,

--- a/projects/scion/e2e-testing/src/workbench/view-drag-main-area-grid.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/view-drag-main-area-grid.e2e-spec.ts
@@ -204,7 +204,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.3', {partId: 'right', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(true);
@@ -229,7 +229,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.3', {partId: 'bottom', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(false);
@@ -256,7 +256,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.4', {partId: 'right', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(true);
@@ -283,7 +283,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.4', {partId: 'left', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(true);
@@ -315,7 +315,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.5', {partId: 'bottom', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(false);
@@ -349,7 +349,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.6', {partId: 'right', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(true);
@@ -376,7 +376,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.3', {partId: 'bottom-middle', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(false);
@@ -404,7 +404,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.3', {partId: 'right-bottom', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(true);
@@ -421,7 +421,7 @@ test.describe('View Drag Main Area', () => {
       await layoutPage.addView('view.3', {partId: 'right', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'mainArea'});
+      await view2.tab.activateDropZones({grid: 'mainArea'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'mainArea', region: 'south'})).toBe(true);
@@ -494,7 +494,7 @@ test.describe('View Drag Main Area', () => {
       await viewPage2.view.tab.mousedown();
 
       // Move mouse over main area to activate the drop zone.
-      await viewPage2.view.tab.moveTo({grid: 'mainArea'});
+      await viewPage2.view.tab.activateDropZones({grid: 'mainArea'});
       const westDropZoneBounds = await appPO.getDropZoneBoundingBox({grid: 'mainArea', region: 'west'});
 
       // Move mouse to the right edge of the drop zone.

--- a/projects/scion/e2e-testing/src/workbench/view-drag-workbench-grid.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/view-drag-workbench-grid.e2e-spec.ts
@@ -36,7 +36,7 @@ test.describe('View Drag Workbench Grid', () => {
       await view2.tab.dragTo({grid: 'workbench', region: 'west'});
 
       // Expect view 2 to be moved to the west of the workbench grid.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -83,7 +83,7 @@ test.describe('View Drag Workbench Grid', () => {
       await view2.tab.dragTo({grid: 'workbench', region: 'west'});
 
       // Expect view 2 to be moved to the west of the workbench grid.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -141,7 +141,7 @@ test.describe('View Drag Workbench Grid', () => {
       await view2.tab.dragTo({grid: 'workbench', region: 'east'});
 
       // Expect view 2 to be moved to the east of the workbench grid.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -188,7 +188,7 @@ test.describe('View Drag Workbench Grid', () => {
       await view2.tab.dragTo({grid: 'workbench', region: 'east'});
 
       // Expect view 2 to be moved to the east of the workbench grid.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -249,7 +249,7 @@ test.describe('View Drag Workbench Grid', () => {
       await view2.tab.dragTo({grid: 'workbench', region: 'south'});
 
       // Expect view 2 to be moved to the south of the workbench grid.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MTreeNode({
             direction: 'column',
@@ -299,7 +299,7 @@ test.describe('View Drag Workbench Grid', () => {
       await view2.tab.dragTo({grid: 'workbench', region: 'south'});
 
       // Expect view 2 to be moved to the south of the workbench grid.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         workbenchGrid: {
           root: new MTreeNode({
             direction: 'column',

--- a/projects/scion/e2e-testing/src/workbench/view-drag-workbench-grid.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/view-drag-workbench-grid.e2e-spec.ts
@@ -357,7 +357,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.3', {partId: 'right', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(true);
@@ -382,7 +382,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.3', {partId: 'bottom', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(false);
@@ -409,7 +409,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.4', {partId: 'right', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(true);
@@ -436,7 +436,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.4', {partId: 'left', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(true);
@@ -468,7 +468,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.5', {partId: 'bottom', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(false);
@@ -502,7 +502,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.6', {partId: 'right', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(true);
@@ -529,7 +529,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.3', {partId: 'bottom-middle', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(false);
@@ -557,7 +557,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.3', {partId: 'right-bottom', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(true);
@@ -583,7 +583,7 @@ test.describe('View Drag Workbench Grid', () => {
       await layoutPage.addView('view.3', {partId: 'right', activateView: true});
 
       const view2 = (await workbenchNavigator.openInNewTab(ViewPagePO)).view;
-      await view2.tab.moveTo({grid: 'workbench'});
+      await view2.tab.activateDropZones({grid: 'workbench'});
 
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'north'})).toBe(false);
       await expect.poll(() => appPO.isDropZoneActive({grid: 'workbench', region: 'south'})).toBe(true);

--- a/projects/scion/e2e-testing/src/workbench/view-drag.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/view-drag.e2e-spec.ts
@@ -153,7 +153,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await view2.part.getPartId(), region: 'center'});
 
       // Expect view 2 not to be moved.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MPart({
             id: await view1.part.getPartId(),
@@ -182,7 +182,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await view2.part.getPartId(), region: 'west'});
 
       // Expect view 2 to be moved to a new part in the west.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -220,7 +220,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await view2.part.getPartId(), region: 'east'});
 
       // Expect view 2 to be moved to a new part in the east.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -261,7 +261,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await view2.part.getPartId(), region: 'north'});
 
       // Expect view 2 to be moved to a new part in the north.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'column',
@@ -302,7 +302,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await view2.part.getPartId(), region: 'south'});
 
       // Expect view 2 to be moved to a new part in the south.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'column',
@@ -349,7 +349,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await layoutPage.view.part.getPartId(), region: 'center'});
 
       // Expect view 2 to be moved to the initial part.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -393,7 +393,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await layoutPage.view.part.getPartId(), region: 'west'});
 
       // Expect view 2 to be moved to a new part in the west of the initial part.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -446,7 +446,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await layoutPage.view.part.getPartId(), region: 'east'});
 
       // Expect view 2 to be moved to a new part in the east of the initial part.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -502,7 +502,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await layoutPage.view.part.getPartId(), region: 'north'});
 
       // Expect view 2 to be moved to a new part in the north of the initial part.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'row',
@@ -558,7 +558,7 @@ test.describe('View Drag', () => {
       await view2.tab.dragTo({partId: await layoutPage.view.part.getPartId(), region: 'south'});
 
       // Expect view 2 to be moved to a new part in the south of the initial part.
-      await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+      await expect(appPO.workbench).toEqualWorkbenchLayout({
         mainAreaGrid: {
           root: new MTreeNode({
             direction: 'row',

--- a/projects/scion/e2e-testing/src/workbench/view-tab-bar.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/view-tab-bar.e2e-spec.ts
@@ -14,6 +14,9 @@ import {StartPagePO} from '../start-page.po';
 import {RouterPagePO} from './page-object/router-page.po';
 import {ViewPagePO} from './page-object/view-page.po';
 import {expectView} from '../matcher/view-matcher';
+import {PerspectivePagePO} from './page-object/perspective-page.po';
+import {MPart, MTreeNode} from '../matcher/to-equal-workbench-layout.matcher';
+import {LayoutPagePO} from './page-object/layout-page.po';
 
 test.describe('View Tabbar', () => {
 
@@ -98,50 +101,247 @@ test.describe('View Tabbar', () => {
     await expectView(testee3ViewPage).not.toBeAttached();
   });
 
-  test('should insert a new view tab into the tabbar after the active view tab by default', async ({appPO, workbenchNavigator}) => {
+  test('should open new view to the right of the active view', async ({appPO, workbenchNavigator}) => {
     await appPO.navigateTo({microfrontendSupport: false});
-    const routerPage = await workbenchNavigator.openInNewTab(RouterPagePO);
 
-    // open view.2
+    // Register Angular routes.
+    const layoutPage = await workbenchNavigator.openInNewTab(LayoutPagePO);
+    await layoutPage.registerRoute({path: '', component: 'router-page', outlet: 'router'});
+
+    const perspectivePage = await workbenchNavigator.openInNewTab(PerspectivePagePO);
+    await perspectivePage.registerPerspective({
+      id: 'perspective',
+      parts: [
+        {id: 'left'},
+        {id: 'right', align: 'right', activate: true},
+      ],
+      views: [
+        // Add views to the left part.
+        {id: 'view.1', partId: 'left'},
+        {id: 'router', partId: 'left', activateView: true}, // TODO [WB-LAYOUT] Change to view.2 and navigate to router page
+        {id: 'view.3', partId: 'left'},
+        {id: 'view.4', partId: 'left'},
+        // Add views to the right part.
+        {id: 'view.5', partId: 'right', activateView: true},
+        {id: 'view.6', partId: 'right'},
+      ],
+    });
+    await appPO.switchPerspective('perspective');
+
+    // Open view in the active part (left part).
+    const routerPage = new RouterPagePO(appPO, {viewId: 'router'});
     await routerPage.enterPath('test-view');
     await routerPage.enterTarget('blank');
     await routerPage.clickNavigate();
 
-    const testee2ViewPage = new ViewPagePO(appPO, {viewId: 'view.2'});
+    // Expect view.2 to be opened to the right of the active view.
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
+      workbenchGrid: {
+        root: new MTreeNode({
+          child1: new MPart({
+            id: 'left',
+            views: [{id: 'view.1'}, {id: 'router'}, {id: 'view.2'}, {id: 'view.3'}, {id: 'view.4'}],
+            activeViewId: 'view.2',
+          }),
+          child2: new MPart({
+            id: 'right',
+            views: [{id: 'view.5'}, {id: 'view.6'}],
+            activeViewId: 'view.5',
+          }),
+          direction: 'row',
+          ratio: .5,
+        }),
+        activePartId: 'left',
+      },
+    });
 
-    await expectView(routerPage).toBeInactive();
-    await expectView(testee2ViewPage).toBeActive();
-    await expect.poll(() => appPO.activePart({inMainArea: true}).getViewIds()).toEqual(['view.1', 'view.2']);
-
-    // open view.3
+    // Open view in the right part.
     await routerPage.view.tab.click();
     await routerPage.enterPath('test-view');
     await routerPage.enterTarget('blank');
+    await routerPage.enterBlankPartId('right');
     await routerPage.clickNavigate();
 
-    const testee3ViewPage = new ViewPagePO(appPO, {viewId: 'view.3'});
-
-    await expectView(routerPage).toBeInactive();
-    await expectView(testee2ViewPage).toBeInactive();
-    await expectView(testee3ViewPage).toBeActive();
-    await expect.poll(() => appPO.activePart({inMainArea: true}).getViewIds()).toEqual(['view.1', 'view.3', 'view.2']);
-
-    // open view.4
-    await routerPage.view.tab.click();
-    await routerPage.enterPath('test-view');
-    await routerPage.enterTarget('blank');
-    await routerPage.clickNavigate();
-
-    const testee4ViewPage = new ViewPagePO(appPO, {viewId: 'view.4'});
-
-    await expectView(routerPage).toBeInactive();
-    await expectView(testee2ViewPage).toBeInactive();
-    await expectView(testee3ViewPage).toBeInactive();
-    await expectView(testee4ViewPage).toBeActive();
-    await expect.poll(() => appPO.activePart({inMainArea: true}).getViewIds()).toEqual(['view.1', 'view.4', 'view.3', 'view.2']);
+    // Expect view.7 to be opened to the right of the active view.
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
+      workbenchGrid: {
+        root: new MTreeNode({
+          child1: new MPart({
+            id: 'left',
+            views: [{id: 'view.1'}, {id: 'router'}, {id: 'view.2'}, {id: 'view.3'}, {id: 'view.4'}],
+            activeViewId: 'router',
+          }),
+          child2: new MPart({
+            id: 'right',
+            views: [{id: 'view.5'}, {id: 'view.7'}, {id: 'view.6'}],
+            activeViewId: 'view.7',
+          }),
+          direction: 'row',
+          ratio: .5,
+        }),
+        activePartId: 'left',
+      },
+    });
   });
 
-  test('should insert a new view tab into the tabbar at the end', async ({appPO, workbenchNavigator}) => {
+  test('should open view moved via drag & drop after the active view', async ({appPO, workbenchNavigator}) => {
+    await appPO.navigateTo({microfrontendSupport: false});
+
+    const perspectivePage = await workbenchNavigator.openInNewTab(PerspectivePagePO);
+    await perspectivePage.registerPerspective({
+      id: 'perspective',
+      parts: [
+        {id: 'left'},
+        {id: 'right', align: 'right', activate: true},
+      ],
+      views: [
+        // Add views to the left part.
+        {id: 'view.1', partId: 'left'},
+        {id: 'view.2', partId: 'left'},
+        {id: 'view.3', partId: 'left', activateView: true},
+        {id: 'view.4', partId: 'left'},
+        // Add views to the right part.
+        {id: 'view.5', partId: 'right', activateView: true},
+        {id: 'view.6', partId: 'right'},
+      ],
+    });
+    await appPO.switchPerspective('perspective');
+
+    // Move view.5 to the left part
+    const view5 = appPO.view({viewId: 'view.5'});
+    await view5.tab.dragTo({partId: 'left', region: 'center'});
+
+    // Expect view.5 to be opened to the right of the active view.
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
+      workbenchGrid: {
+        root: new MTreeNode({
+          child1: new MPart({
+            id: 'left',
+            views: [{id: 'view.1'}, {id: 'view.2'}, {id: 'view.3'}, {id: 'view.5'}, {id: 'view.4'}],
+            activeViewId: 'view.5',
+          }),
+          child2: new MPart({
+            id: 'right',
+            views: [{id: 'view.6'}],
+            activeViewId: 'view.6',
+          }),
+          direction: 'row',
+          ratio: .5,
+        }),
+        activePartId: 'left',
+      },
+    });
+  });
+
+  test('should activate the view to the left of the view that is dragged out of the tab bar', async ({appPO, workbenchNavigator}) => {
+    await appPO.navigateTo({microfrontendSupport: false});
+
+    const perspectivePage = await workbenchNavigator.openInNewTab(PerspectivePagePO);
+    await perspectivePage.registerPerspective({
+      id: 'perspective',
+      parts: [
+        {id: 'part'},
+      ],
+      views: [
+        {id: 'view.1', partId: 'part'},
+        {id: 'view.2', partId: 'part'},
+        {id: 'view.3', partId: 'part', activateView: true},
+        {id: 'view.4', partId: 'part'},
+      ],
+    });
+    await appPO.switchPerspective('perspective');
+
+    // Drag view.3 out of the tabbar.
+    const view3 = appPO.view({viewId: 'view.3'});
+    await view3.tab.dragTo({partId: 'part', region: 'center'}, {steps: 100, performDrop: false});
+
+    // Expect view.2 to be activated.
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
+      workbenchGrid: {
+        root: new MPart({
+          id: 'part',
+          views: [{id: 'view.1'}, {id: 'view.2'}, {id: 'view.4'}],
+          activeViewId: 'view.2',
+        }),
+        activePartId: 'part',
+      },
+    });
+  });
+
+  test('should not change the view order when dragging a view to its own part (noop)', async ({appPO, workbenchNavigator}) => {
+    await appPO.navigateTo({microfrontendSupport: false});
+
+    const perspectivePage = await workbenchNavigator.openInNewTab(PerspectivePagePO);
+    await perspectivePage.registerPerspective({
+      id: 'perspective',
+      parts: [
+        {id: 'part'},
+      ],
+      views: [
+        {id: 'view.1', partId: 'part'},
+        {id: 'view.2', partId: 'part'},
+        {id: 'view.3', partId: 'part', activateView: true},
+        {id: 'view.4', partId: 'part'},
+      ],
+    });
+    await appPO.switchPerspective('perspective');
+
+    // Drag view.3 to its own part.
+    const view3 = appPO.view({viewId: 'view.3'});
+    await view3.tab.dragTo({partId: 'part', region: 'center'}, {steps: 100});
+
+    // Expect tab order not to be changed.
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
+      workbenchGrid: {
+        root: new MPart({
+          id: 'part',
+          views: [{id: 'view.1'}, {id: 'view.2'}, {id: 'view.3'}, {id: 'view.4'}],
+          activeViewId: 'view.3',
+        }),
+        activePartId: 'part',
+      },
+    });
+  });
+
+  test('should cancel drag operation if pressing escape', async ({appPO, workbenchNavigator}) => {
+    await appPO.navigateTo({microfrontendSupport: false});
+
+    const perspectivePage = await workbenchNavigator.openInNewTab(PerspectivePagePO);
+    await perspectivePage.registerPerspective({
+      id: 'perspective',
+      parts: [
+        {id: 'part'},
+      ],
+      views: [
+        {id: 'view.1', partId: 'part'},
+        {id: 'view.2', partId: 'part'},
+        {id: 'view.3', partId: 'part', activateView: true},
+        {id: 'view.4', partId: 'part'},
+      ],
+    });
+    await appPO.switchPerspective('perspective');
+
+    // Drag view.3 out of the tabbar.
+    const view3 = appPO.view({viewId: 'view.3'});
+    await view3.tab.dragTo({partId: 'part', region: 'center'}, {steps: 100, performDrop: false});
+
+    // Cancel drag operation.
+    await appPO.workbench.press('Escape');
+
+    // Expect views not to be changed.
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
+      workbenchGrid: {
+        root: new MPart({
+          id: 'part',
+          views: [{id: 'view.1'}, {id: 'view.2'}, {id: 'view.3'}, {id: 'view.4'}],
+          activeViewId: 'view.3',
+        }),
+        activePartId: 'part',
+      },
+    });
+  });
+
+  test('should allow opening view at the end', async ({appPO, workbenchNavigator}) => {
     await appPO.navigateTo({microfrontendSupport: false});
     const routerPage = await workbenchNavigator.openInNewTab(RouterPagePO);
 
@@ -187,7 +387,7 @@ test.describe('View Tabbar', () => {
     await expect.poll(() => appPO.activePart({inMainArea: true}).getViewIds()).toEqual(['view.1', 'view.2', 'view.3', 'view.4']);
   });
 
-  test('should insert a new view tab into the tabbar at the start', async ({appPO, workbenchNavigator}) => {
+  test('should allow opening view at the start', async ({appPO, workbenchNavigator}) => {
     await appPO.navigateTo({microfrontendSupport: false});
     const routerPage = await workbenchNavigator.openInNewTab(RouterPagePO);
 
@@ -233,7 +433,7 @@ test.describe('View Tabbar', () => {
     await expect.poll(() => appPO.activePart({inMainArea: true}).getViewIds()).toEqual(['view.4', 'view.3', 'view.2', 'view.1']);
   });
 
-  test('should insert a new view tab into the tabbar at a custom position', async ({appPO, workbenchNavigator}) => {
+  test('should allow opening view at a specific position', async ({appPO, workbenchNavigator}) => {
     await appPO.navigateTo({microfrontendSupport: false});
     const routerPage = await workbenchNavigator.openInNewTab(RouterPagePO);
 

--- a/projects/scion/e2e-testing/src/workbench/workbench-layout-migration.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/workbench-layout-migration.e2e-spec.ts
@@ -27,7 +27,7 @@ test.describe('Workbench Layout Migration', () => {
     await page.goto(`/?${WorkenchStartupQueryParams.STANDALONE}=true/#/(view.3:test-view//view.2:test-view//view.1:test-view)?parts=eyJyb290Ijp7Im5vZGVJZCI6IjhkMWQ4MzA1LTgxYzItNDllOC05NWE3LWFlYjNlODM1ODFhMSIsImNoaWxkMSI6eyJ2aWV3SWRzIjpbInZpZXcuMSJdLCJwYXJ0SWQiOiIzOGY5MTU0MS03ZmRjLTRjNzEtYmVjMi0xZDVhZDc1MjNiZWUiLCJhY3RpdmVWaWV3SWQiOiJ2aWV3LjEifSwiY2hpbGQyIjp7InZpZXdJZHMiOlsidmlldy4yIiwidmlldy4zIl0sInBhcnRJZCI6ImZlZDM4MDExLTY2YjctNDZjZC1iYjQyLTMwY2U2ZjBmODA3MSIsImFjdGl2ZVZpZXdJZCI6InZpZXcuMyJ9LCJkaXJlY3Rpb24iOiJyb3ciLCJyYXRpbyI6MC41fSwiYWN0aXZlUGFydElkIjoiMzhmOTE1NDEtN2ZkYy00YzcxLWJlYzItMWQ1YWQ3NTIzYmVlIiwidXVpZCI6IjFlMjIzN2U1LWE3MzAtNDk1NC1iYWJmLWNkMzRjMjM3OWI1ZSJ9`);
     await appPO.waitUntilWorkbenchStarted();
 
-    await expect(appPO.workbenchLocator).toEqualWorkbenchLayout({
+    await expect(appPO.workbench).toEqualWorkbenchLayout({
       workbenchGrid: {
         root: new MPart({
           id: MAIN_AREA,

--- a/projects/scion/e2e-testing/src/workbench/workbench-navigator.ts
+++ b/projects/scion/e2e-testing/src/workbench/workbench-navigator.ts
@@ -74,7 +74,7 @@ export class WorkbenchNavigator {
       }
       case DialogOpenerPagePO: {
         await startPage.openWorkbenchView('e2e-test-dialog-opener');
-        return new DialogOpenerPagePO(this._appPO, this._appPO.view({viewId, cssClass: 'e2e-test-dialog-opener'}));
+        return new DialogOpenerPagePO(this._appPO.view({viewId, cssClass: 'e2e-test-dialog-opener'}));
       }
       case NotificationOpenerPagePO: {
         await startPage.openWorkbenchView('e2e-test-notification-opener');
@@ -82,7 +82,7 @@ export class WorkbenchNavigator {
       }
       case PopupOpenerPagePO: {
         await startPage.openWorkbenchView('e2e-test-popup-opener');
-        return new PopupOpenerPagePO(this._appPO, this._appPO.view({viewId, cssClass: 'e2e-test-popup-opener'}));
+        return new PopupOpenerPagePO(this._appPO.view({viewId, cssClass: 'e2e-test-popup-opener'}));
       }
       case RouterPagePO: {
         await startPage.openWorkbenchView('e2e-test-router');

--- a/projects/scion/e2e-testing/src/workbench/workbench-theme.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/workbench-theme.e2e-spec.ts
@@ -25,8 +25,8 @@ test.describe('Workbench', () => {
       await expect(testPage.theme).toHaveText('scion-light');
       await expect(testPage.colorScheme).toHaveText('light');
 
-      await expect(appPO.workbenchLocator).toHaveCSS('background-color', 'rgb(255, 255, 255)');
-      await expect(appPO.workbenchLocator).toHaveCSS('color-scheme', 'light');
+      await expect(appPO.workbench).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+      await expect(appPO.workbench).toHaveCSS('color-scheme', 'light');
     });
 
     await test.step('dark theme', async () => {
@@ -35,8 +35,8 @@ test.describe('Workbench', () => {
       await expect(testPage.theme).toHaveText('scion-dark');
       await expect(testPage.colorScheme).toHaveText('dark');
 
-      await expect(appPO.workbenchLocator).toHaveCSS('background-color', 'rgb(29, 29, 29)');
-      await expect(appPO.workbenchLocator).toHaveCSS('color-scheme', 'dark');
+      await expect(appPO.workbench).toHaveCSS('background-color', 'rgb(29, 29, 29)');
+      await expect(appPO.workbench).toHaveCSS('color-scheme', 'dark');
     });
   });
 });

--- a/projects/scion/e2e-testing/src/workbench/workbench-unmount.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/workbench-unmount.e2e-spec.ts
@@ -26,7 +26,7 @@ test.describe('Workbench Component', () => {
     await appPO.openNewViewTab();
 
     // Expect the workbench component to be constructed.
-    await expect(appPO.workbenchLocator).toBeVisible();
+    await expect(appPO.workbench).toBeVisible();
     await expect.poll(() => consoleLogs.get({severity: 'debug', message: /WorkbenchComponent#construct/})).toHaveLength(1);
     await expect.poll(() => appPO.views().count()).toBeGreaterThan(0);
     consoleLogs.clear();
@@ -35,7 +35,7 @@ test.describe('Workbench Component', () => {
     await appPO.header.clickMenuItem({cssClass: 'e2e-navigate-to-blank-page'});
 
     // Expect the workbench component to be destroyed.
-    await expect(appPO.workbenchLocator).not.toBeAttached();
+    await expect(appPO.workbench).not.toBeAttached();
     await expect.poll(() => consoleLogs.get({severity: 'debug', message: /WorkbenchComponent#destroy/})).toHaveLength(1);
   });
 
@@ -102,14 +102,14 @@ test.describe('Workbench Component', () => {
     await appPO.header.clickMenuItem({cssClass: 'e2e-navigate-to-blank-page'});
 
     // Expect the DOM not to contain workbench elements.
-    await expect(appPO.workbenchLocator).not.toBeAttached();
+    await expect(appPO.workbench).not.toBeAttached();
     await expectView(viewPage).not.toBeAttached();
 
     // Re-mount the workbench component by navigating the primary router.
     await appPO.header.clickMenuItem({cssClass: 'e2e-navigate-to-workbench-page'});
 
     // Expect the view and the microfrontend to display.
-    await expect(appPO.workbenchLocator).toBeVisible();
+    await expect(appPO.workbench).toBeVisible();
     await expectView(viewPage).toBeActive();
   });
 

--- a/projects/scion/workbench/src/lib/layout/main-area-layout/main-area-layout.component.ts
+++ b/projects/scion/workbench/src/lib/layout/main-area-layout/main-area-layout.component.ts
@@ -8,12 +8,11 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Component, HostBinding} from '@angular/core';
+import {Component, HostBinding, Inject} from '@angular/core';
 import {ɵWorkbenchPart} from '../../part/ɵworkbench-part.model';
 import {MPart, MTreeNode} from '../workbench-layout.model';
 import {WorkbenchLayoutService} from '../workbench-layout.service';
 import {GridElementComponent} from '../grid-element/grid-element.component';
-import {ɵWorkbenchService} from '../../ɵworkbench.service';
 import {ViewDragService} from '../../view-dnd/view-drag.service';
 import {ViewDropZoneDirective, WbViewDropEvent} from '../../view-dnd/view-drop-zone.directive';
 import {RequiresDropZonePipe} from '../../view-dnd/requires-drop-zone.pipe';
@@ -21,6 +20,7 @@ import {RouterOutlet} from '@angular/router';
 import {SciViewportComponent} from '@scion/components/viewport';
 import {GridElementVisiblePipe} from '../../common/grid-element-visible.pipe';
 import {NgIf} from '@angular/common';
+import {WORKBENCH_ID} from '../../workbench-id';
 
 /**
  * Renders the layout of the {@link MAIN_AREA} part.
@@ -67,8 +67,8 @@ export class MainAreaLayoutComponent {
     return this._part.id;
   }
 
-  constructor(private _part: ɵWorkbenchPart,
-              private _workbenchService: ɵWorkbenchService,
+  constructor(@Inject(WORKBENCH_ID) private _workbenchId: string,
+              private _part: ɵWorkbenchPart,
               private _workbenchLayoutService: WorkbenchLayoutService,
               private _viewDragService: ViewDragService) {
   }
@@ -85,15 +85,15 @@ export class MainAreaLayoutComponent {
   public onViewDrop(event: WbViewDropEvent): void {
     this._viewDragService.dispatchViewMoveEvent({
       source: {
-        appInstanceId: event.dragData.appInstanceId,
+        workbenchId: event.dragData.workbenchId,
         partId: event.dragData.partId,
         viewId: event.dragData.viewId,
         viewUrlSegments: event.dragData.viewUrlSegments,
       },
       target: {
-        appInstanceId: this._workbenchService.appInstanceId,
+        workbenchId: this._workbenchId,
         elementId: this.root instanceof MPart ? this.root.id : this.root.nodeId,
-        region: event.dropRegion,
+        region: event.dropRegion as 'west' | 'east' | 'south', // north and center drop zones not installed
         newPart: {ratio: .2},
       },
     });

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.component.spec.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.component.spec.ts
@@ -23,11 +23,11 @@ import {MAIN_AREA} from './workbench-layout';
 import {toHaveTransientStateCustomMatcher} from '../testing/jasmine/matcher/to-have-transient-state.matcher';
 import {enterTransientViewState, TestComponent, withComponentContent, withTransientStateInputElement} from '../testing/test.component';
 import {styleFixture, waitForInitialWorkbenchLayout, waitUntilStable} from '../testing/testing.util';
-import {ɵWorkbenchService} from '../ɵworkbench.service';
 import {WorkbenchTestingModule} from '../testing/workbench-testing.module';
 import {RouterTestingModule} from '@angular/router/testing';
 import {MPart, MTreeNode} from './workbench-layout.model';
 import {WorkbenchPartRegistry} from '../part/workbench-part.registry';
+import {WORKBENCH_ID} from '../workbench-id';
 
 describe('WorkbenchLayout', () => {
 
@@ -163,13 +163,13 @@ describe('WorkbenchLayout', () => {
     // WHEN moving view.3 to position 0
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         insertionIndex: 0,
       },
@@ -183,13 +183,13 @@ describe('WorkbenchLayout', () => {
     // WHEN moving view.3 to position 1
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         insertionIndex: 1,
       },
@@ -203,13 +203,13 @@ describe('WorkbenchLayout', () => {
     // WHEN moving view.3 to position 2
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         insertionIndex: 2,
       },
@@ -223,13 +223,13 @@ describe('WorkbenchLayout', () => {
     // WHEN moving view.3 to position 3
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         insertionIndex: 3,
       },
@@ -243,13 +243,13 @@ describe('WorkbenchLayout', () => {
     // WHEN moving view.3 to position 4
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         insertionIndex: undefined,
       },
@@ -305,13 +305,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -379,13 +379,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the west
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'west',
         newPart: {id: 'WEST'},
@@ -453,13 +453,13 @@ describe('WorkbenchLayout', () => {
     // Move view 1 to a new part in the north
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'north',
         newPart: {id: 'NORTH'},
@@ -527,13 +527,13 @@ describe('WorkbenchLayout', () => {
     // Move view 1 to a new part in the south
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'south',
         newPart: {id: 'SOUTH'},
@@ -601,15 +601,14 @@ describe('WorkbenchLayout', () => {
     // Move view 1 to a new part in the center
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
-        region: 'center',
       },
     });
     await waitUntilStable();
@@ -687,13 +686,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view-3', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -722,15 +721,14 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to the new part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'EAST',
-        region: 'center',
       },
     });
     await waitUntilStable();
@@ -755,15 +753,14 @@ describe('WorkbenchLayout', () => {
     // Move view 1 to the new part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.1',
         viewUrlSegments: [new UrlSegment('view-1', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'EAST',
-        region: 'center',
       },
     });
     await waitUntilStable();
@@ -826,13 +823,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST-1'},
@@ -859,13 +856,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east of part EAST-1
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST-1',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST-2'},
@@ -933,13 +930,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -966,13 +963,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the west of part 1
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'west',
         newPart: {id: 'WEST-2'},
@@ -1040,13 +1037,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -1072,13 +1069,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the north of part 1
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'north',
         newPart: {id: 'NORTH'},
@@ -1146,13 +1143,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -1178,13 +1175,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the south of part 1
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'south',
         newPart: {id: 'SOUTH'},
@@ -1270,13 +1267,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view-3', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -1305,13 +1302,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the south of part 2
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'EAST',
         region: 'south',
         newPart: {id: 'SOUTH-EAST'},
@@ -1344,13 +1341,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the south of part 1
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'SOUTH-EAST',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         newPart: {id: 'SOUTH-WEST'},
         region: 'south',
@@ -1425,13 +1422,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the south
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'south',
         newPart: {id: 'SOUTH'},
@@ -1457,15 +1454,14 @@ describe('WorkbenchLayout', () => {
     // Move view 2 back to the main part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'SOUTH',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
-        region: 'center',
       },
     });
     await waitUntilStable();
@@ -1525,13 +1521,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -1557,13 +1553,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the south
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'south',
         newPart: {id: 'SOUTH'},
@@ -1631,13 +1627,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the west
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'west',
         newPart: {id: 'WEST'},
@@ -1663,13 +1659,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the south
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'WEST',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'south',
         newPart: {id: 'SOUTH'},
@@ -1855,13 +1851,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST-1'},
@@ -1909,13 +1905,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST-1',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view-3', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'EAST-1',
         region: 'east',
         newPart: {id: 'EAST-2'},
@@ -1977,13 +1973,13 @@ describe('WorkbenchLayout', () => {
     // Move view 4 to a new part in the west
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST-2',
         viewId: 'view.4',
         viewUrlSegments: [new UrlSegment('view-4', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'west',
         newPart: {id: 'WEST-1'},
@@ -2023,13 +2019,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the west
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST-2',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view-3', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'WEST-1',
         region: 'west',
         newPart: {id: 'WEST-2'},
@@ -2069,13 +2065,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the north
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST-1',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view-2', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'north',
         newPart: {id: 'NORTH-1'},
@@ -2222,13 +2218,13 @@ describe('WorkbenchLayout', () => {
     // Move view.2 to the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'right'},
@@ -2253,13 +2249,13 @@ describe('WorkbenchLayout', () => {
     // Move view.3 to the north of view.2
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'right',
         region: 'north',
         newPart: {id: 'top-right'},
@@ -2332,13 +2328,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -2363,13 +2359,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the west of the main part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'west',
         newPart: {id: 'WEST-2'},
@@ -2443,13 +2439,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST-1'},
@@ -2475,13 +2471,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'EAST-1',
         region: 'east',
         newPart: {id: 'EAST-2'},
@@ -2512,13 +2508,13 @@ describe('WorkbenchLayout', () => {
     // Move view 4 to a new part in the west
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.4',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'west',
         newPart: {id: 'WEST-1'},
@@ -2554,13 +2550,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the west
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST-2',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'WEST-1',
         region: 'west',
         newPart: {id: 'WEST-2'},
@@ -2596,13 +2592,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the north
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST-1',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'north',
         newPart: {id: 'NORTH-1'},
@@ -2732,13 +2728,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -2763,13 +2759,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the south of EAST part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'EAST',
         region: 'south',
         newPart: {id: 'SOUTH'},
@@ -2799,13 +2795,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the north of EAST part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'EAST',
         region: 'north',
         newPart: {id: 'NORTH'},
@@ -2878,13 +2874,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -2909,13 +2905,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the north of EAST part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'EAST',
         region: 'north',
         newPart: {id: 'NORTH'},
@@ -2945,13 +2941,13 @@ describe('WorkbenchLayout', () => {
     // Move view 3 to a new part in the south of NORTH part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST',
         viewId: 'view.3',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'NORTH',
         region: 'south',
         newPart: {id: 'SOUTH'},
@@ -3018,13 +3014,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the east
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'main',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'east',
         newPart: {id: 'EAST'},
@@ -3048,13 +3044,13 @@ describe('WorkbenchLayout', () => {
     // Move view 2 to a new part in the west of main part
     TestBed.inject(ViewDragService).dispatchViewMoveEvent({
       source: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         partId: 'EAST',
         viewId: 'view.2',
         viewUrlSegments: [new UrlSegment('view', {})],
       },
       target: {
-        appInstanceId: TestBed.inject(ɵWorkbenchService).appInstanceId,
+        workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
         region: 'west',
         newPart: {id: 'WEST'},

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.component.spec.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.component.spec.ts
@@ -171,7 +171,7 @@ describe('WorkbenchLayout', () => {
       target: {
         workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
-        insertionIndex: 0,
+        position: 'start',
       },
     });
     await waitUntilStable();
@@ -191,7 +191,7 @@ describe('WorkbenchLayout', () => {
       target: {
         workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
-        insertionIndex: 1,
+        position: 1,
       },
     });
     await waitUntilStable();
@@ -211,7 +211,7 @@ describe('WorkbenchLayout', () => {
       target: {
         workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
-        insertionIndex: 2,
+        position: 2,
       },
     });
     await waitUntilStable();
@@ -231,7 +231,7 @@ describe('WorkbenchLayout', () => {
       target: {
         workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
-        insertionIndex: 3,
+        position: 3,
       },
     });
     await waitUntilStable();
@@ -251,7 +251,7 @@ describe('WorkbenchLayout', () => {
       target: {
         workbenchId: TestBed.inject(WORKBENCH_ID),
         elementId: 'main',
-        insertionIndex: undefined,
+        position: 'end',
       },
     });
     await waitUntilStable();

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.component.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.component.ts
@@ -8,20 +8,20 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Component} from '@angular/core';
+import {Component, Inject} from '@angular/core';
 import {WorkbenchLayoutService} from './workbench-layout.service';
 import {ɵWorkbenchLayout} from './ɵworkbench-layout';
 import {GridElementComponent} from './grid-element/grid-element.component';
 import {NgIf} from '@angular/common';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {ViewDragService} from '../view-dnd/view-drag.service';
-import {ɵWorkbenchService} from '../ɵworkbench.service';
 import {MPart, MTreeNode} from './workbench-layout.model';
 import {RequiresDropZonePipe} from '../view-dnd/requires-drop-zone.pipe';
 import {ViewDropZoneDirective, WbViewDropEvent} from '../view-dnd/view-drop-zone.directive';
 import {RouterOutlet} from '@angular/router';
 import {SciViewportComponent} from '@scion/components/viewport';
 import {GridElementVisiblePipe} from '../common/grid-element-visible.pipe';
+import {WORKBENCH_ID} from '../workbench-id';
 
 /**
  * Renders the layout of the workbench.
@@ -67,9 +67,9 @@ export class WorkbenchLayoutComponent {
   public layout: ɵWorkbenchLayout | undefined;
   public root: MTreeNode | MPart | undefined;
 
-  constructor(workbenchLayoutService: WorkbenchLayoutService,
-              private _workbenchService: ɵWorkbenchService,
-              private _viewDragService: ViewDragService) {
+  constructor(@Inject(WORKBENCH_ID) private _workbenchId: string,
+              private _viewDragService: ViewDragService,
+              workbenchLayoutService: WorkbenchLayoutService) {
     workbenchLayoutService.layout$
       .pipe(takeUntilDestroyed())
       .subscribe(layout => {
@@ -81,15 +81,15 @@ export class WorkbenchLayoutComponent {
   public onViewDrop(event: WbViewDropEvent): void {
     this._viewDragService.dispatchViewMoveEvent({
       source: {
-        appInstanceId: event.dragData.appInstanceId,
+        workbenchId: event.dragData.workbenchId,
         partId: event.dragData.partId,
         viewId: event.dragData.viewId,
         viewUrlSegments: event.dragData.viewUrlSegments,
       },
       target: {
-        appInstanceId: this._workbenchService.appInstanceId,
+        workbenchId: this._workbenchId,
         elementId: this.root instanceof MPart ? this.root.id : this.root!.nodeId,
-        region: event.dropRegion,
+        region: event.dropRegion as 'west' | 'east' | 'south', // north and center drop zones not installed
         newPart: {ratio: .2},
       },
     });

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.spec.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.spec.ts
@@ -21,6 +21,49 @@ describe('WorkbenchLayout', () => {
 
   beforeEach(() => jasmine.addMatchers(toEqualWorkbenchLayoutCustomMatcher));
 
+  it('should allow adding views', () => {
+    const layout = TestBed.inject(ɵWorkbenchLayoutFactory)
+      .addPart('A')
+      .addView('view.1', {partId: 'A'})
+      .addView('view.2', {partId: 'A', activateView: true})
+      .addView('view.3', {partId: 'A'});
+
+    // add view without specifying position
+    expect(layout
+      .addView('view.4', {partId: 'A'})
+      .part({by: {partId: 'A'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.1', 'view.2', 'view.3', 'view.4']);
+
+    // add view at the start
+    expect(layout
+      .addView('view.4', {partId: 'A', position: 'start'})
+      .part({by: {partId: 'A'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.4', 'view.1', 'view.2', 'view.3']);
+
+    // add view at the end
+    expect(layout
+      .addView('view.4', {partId: 'A', position: 'end'})
+      .part({by: {partId: 'A'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.1', 'view.2', 'view.3', 'view.4']);
+
+    // add view before the active view
+    expect(layout
+      .addView('view.4', {partId: 'A', position: 'before-active-view'})
+      .part({by: {partId: 'A'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.1', 'view.4', 'view.2', 'view.3']);
+
+    // add view after the active view
+    expect(layout
+      .addView('view.4', {partId: 'A', position: 'after-active-view'})
+      .part({by: {partId: 'A'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.1', 'view.2', 'view.4', 'view.3']);
+  });
+
   /**
    * +----+---+
    * | B  |   |
@@ -801,7 +844,7 @@ describe('WorkbenchLayout', () => {
       .addView('view.2', {partId: 'A'})
       .addView('view.3', {partId: 'A'})
       .addView('view.4', {partId: 'A'})
-      .moveView('view.2', 'A')
+      .moveView('view.2', 'A', {position: 'end'})
       .part({by: {partId: 'A'}})
       .views.map(view => view.id),
     ).toEqual(['view.1', 'view.3', 'view.4', 'view.2']);
@@ -815,10 +858,100 @@ describe('WorkbenchLayout', () => {
       .addView('view.2', {partId: 'A'})
       .addView('view.3', {partId: 'A'})
       .addView('view.4', {partId: 'A'})
-      .moveView('view.3', 'A', {position: 0})
+      .moveView('view.3', 'A', {position: 'start'})
       .part({by: {partId: 'A'}})
       .views.map(view => view.id),
     ).toEqual(['view.3', 'view.1', 'view.2', 'view.4']);
+
+    // move 'view.1' before the active view
+    expect(TestBed.inject(ɵWorkbenchLayoutFactory)
+      .addPart(MAIN_AREA)
+      .addPart('B', {relativeTo: 'A', align: 'left'})
+      .addPart('C', {relativeTo: 'B', align: 'bottom'})
+      .addView('view.1', {partId: 'A'})
+      .addView('view.2', {partId: 'A'})
+      .addView('view.3', {partId: 'A', activateView: true})
+      .addView('view.4', {partId: 'A'})
+      .moveView('view.1', 'A', {position: 'before-active-view'})
+      .part({by: {partId: 'A'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.2', 'view.1', 'view.3', 'view.4']);
+
+    // move 'view.2' to a different part before the active view
+    expect(TestBed.inject(ɵWorkbenchLayoutFactory)
+      .addPart(MAIN_AREA)
+      .addPart('B', {relativeTo: 'A', align: 'left'})
+      .addPart('C', {relativeTo: 'B', align: 'bottom'})
+      .addView('view.1', {partId: 'A', activateView: true})
+      .addView('view.2', {partId: 'A'})
+      .addView('view.3', {partId: 'A'})
+      .addView('view.4', {partId: 'C'})
+      .addView('view.5', {partId: 'C', activateView: true})
+      .addView('view.6', {partId: 'C'})
+      .moveView('view.2', 'C', {position: 'before-active-view'})
+      .part({by: {partId: 'C'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.4', 'view.2', 'view.5', 'view.6']);
+
+    // move 'view.1' after the active view
+    expect(TestBed.inject(ɵWorkbenchLayoutFactory)
+      .addPart(MAIN_AREA)
+      .addPart('B', {relativeTo: 'A', align: 'left'})
+      .addPart('C', {relativeTo: 'B', align: 'bottom'})
+      .addView('view.1', {partId: 'A'})
+      .addView('view.2', {partId: 'A'})
+      .addView('view.3', {partId: 'A', activateView: true})
+      .addView('view.4', {partId: 'A'})
+      .moveView('view.1', 'A', {position: 'after-active-view'})
+      .part({by: {partId: 'A'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.2', 'view.3', 'view.1', 'view.4']);
+
+    // move 'view.2' to a different part after the active view
+    expect(TestBed.inject(ɵWorkbenchLayoutFactory)
+      .addPart(MAIN_AREA)
+      .addPart('B', {relativeTo: 'A', align: 'left'})
+      .addPart('C', {relativeTo: 'B', align: 'bottom'})
+      .addView('view.1', {partId: 'A', activateView: true})
+      .addView('view.2', {partId: 'A'})
+      .addView('view.3', {partId: 'A'})
+      .addView('view.4', {partId: 'C'})
+      .addView('view.5', {partId: 'C', activateView: true})
+      .addView('view.6', {partId: 'C'})
+      .moveView('view.2', 'C', {position: 'after-active-view'})
+      .part({by: {partId: 'C'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.4', 'view.5', 'view.2', 'view.6']);
+
+    // move 'view.2' without specifying a position
+    expect(TestBed.inject(ɵWorkbenchLayoutFactory)
+      .addPart(MAIN_AREA)
+      .addPart('B', {relativeTo: 'A', align: 'left'})
+      .addPart('C', {relativeTo: 'B', align: 'bottom'})
+      .addView('view.1', {partId: 'A'})
+      .addView('view.2', {partId: 'A'})
+      .addView('view.3', {partId: 'A'})
+      .addView('view.4', {partId: 'A'})
+      .moveView('view.2', 'A')
+      .part({by: {partId: 'A'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.1', 'view.2', 'view.3', 'view.4']);
+
+    // move 'view.2' to a different part without specifying a position
+    expect(TestBed.inject(ɵWorkbenchLayoutFactory)
+      .addPart(MAIN_AREA)
+      .addPart('B', {relativeTo: 'A', align: 'left'})
+      .addPart('C', {relativeTo: 'B', align: 'bottom'})
+      .addView('view.1', {partId: 'A', activateView: true})
+      .addView('view.2', {partId: 'A'})
+      .addView('view.3', {partId: 'A'})
+      .addView('view.4', {partId: 'C'})
+      .addView('view.5', {partId: 'C', activateView: true})
+      .addView('view.6', {partId: 'C'})
+      .moveView('view.2', 'C')
+      .part({by: {partId: 'C'}})
+      .views.map(view => view.id),
+    ).toEqual(['view.4', 'view.5', 'view.6', 'view.2']);
   });
 
   /**
@@ -1505,7 +1638,7 @@ describe('WorkbenchLayout', () => {
     // Activate adjacent view
     workbenchLayout = workbenchLayout.activateAdjacentView('view.2');
     expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('main');
-    expect(workbenchLayout.part({by: {partId: 'part'}}).activeViewId).toEqual('view.3');
+    expect(workbenchLayout.part({by: {partId: 'part'}}).activeViewId).toEqual('view.1');
 
     // Activate adjacent view
     workbenchLayout = workbenchLayout.activateAdjacentView('view.3');
@@ -1513,9 +1646,14 @@ describe('WorkbenchLayout', () => {
     expect(workbenchLayout.part({by: {partId: 'part'}}).activeViewId).toEqual('view.2');
 
     // Activate adjacent view
+    workbenchLayout = workbenchLayout.activateAdjacentView('view.1');
+    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('main');
+    expect(workbenchLayout.part({by: {partId: 'part'}}).activeViewId).toEqual('view.2');
+
+    // Activate adjacent view
     workbenchLayout = workbenchLayout.activateAdjacentView('view.2', {activatePart: true});
     expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part');
-    expect(workbenchLayout.part({by: {partId: 'part'}}).activeViewId).toEqual('view.3');
+    expect(workbenchLayout.part({by: {partId: 'part'}}).activeViewId).toEqual('view.1');
   });
 
   it('should allow activating a part', () => {

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.ts
@@ -47,7 +47,7 @@ export interface WorkbenchLayout {
    *        @property activatePart - Controls whether to activate the part that contains the view. If not set, defaults to `false`.
    * @return a copy of this layout with the view added.
    */
-  addView(id: string, options: {partId: string; position?: number; activateView?: boolean; activatePart?: boolean}): WorkbenchLayout;
+  addView(id: string, options: {partId: string; position?: number | 'start' | 'end' | 'before-active-view' | 'after-active-view'; activateView?: boolean; activatePart?: boolean}): WorkbenchLayout;
 
   /**
    * Removes given view from the layout.

--- a/projects/scion/workbench/src/lib/part/part-bar/part-bar.component.ts
+++ b/projects/scion/workbench/src/lib/part/part-bar/part-bar.component.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Component, DestroyRef, ElementRef, HostListener, NgZone, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {Component, DestroyRef, ElementRef, HostListener, Inject, NgZone, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {ViewTabComponent} from '../view-tab/view-tab.component';
 import {WorkbenchLayoutService} from '../../layout/workbench-layout.service';
 import {filter, map, mergeMap, startWith, switchMap, take, takeUntil} from 'rxjs/operators';
@@ -20,13 +20,13 @@ import {ɵWorkbenchPart} from '../ɵworkbench-part.model';
 import {filterArray, mapArray, observeInside, subscribeInside} from '@scion/toolkit/operators';
 import {SciViewportComponent} from '@scion/components/viewport';
 import {WorkbenchRouter} from '../../routing/workbench-router.service';
-import {ɵWorkbenchService} from '../../ɵworkbench.service';
 import {SciDimensionModule} from '@scion/components/dimension';
 import {AsyncPipe, NgFor, NgIf} from '@angular/common';
 import {PartActionBarComponent} from '../part-action-bar/part-action-bar.component';
 import {ViewListButtonComponent} from '../view-list-button/view-list-button.component';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {fromDimension$} from '@scion/toolkit/observable';
+import {WORKBENCH_ID} from '../../workbench-id';
 
 /**
  * Renders view tabs and actions of a {@link WorkbenchPart}.
@@ -137,7 +137,7 @@ export class PartBarComponent implements OnInit {
     );
 
   constructor(host: ElementRef<HTMLElement>,
-              private _workbenchService: ɵWorkbenchService,
+              @Inject(WORKBENCH_ID) private _workbenchId: string,
               private _workbenchLayoutService: WorkbenchLayoutService,
               private _router: WorkbenchRouter,
               private _viewTabDragImageRenderer: ViewTabDragImageRenderer,
@@ -301,13 +301,13 @@ export class PartBarComponent implements OnInit {
     const dropIndex = this.dropTargetViewTab === 'end' ? undefined : this._viewTabs.indexOf(this.dropTargetViewTab!);
     this._viewDragService.dispatchViewMoveEvent({
       source: {
-        appInstanceId: this._dragData!.appInstanceId,
+        workbenchId: this._dragData!.workbenchId,
         partId: this._dragData!.partId,
         viewId: this._dragData!.viewId,
         viewUrlSegments: this._dragData!.viewUrlSegments,
       },
       target: {
-        appInstanceId: this._workbenchService.appInstanceId,
+        workbenchId: this._workbenchId,
         insertionIndex: dropIndex,
         elementId: this._part.id,
       },

--- a/projects/scion/workbench/src/lib/part/part-bar/part-bar.component.ts
+++ b/projects/scion/workbench/src/lib/part/part-bar/part-bar.component.ts
@@ -298,7 +298,6 @@ export class PartBarComponent implements OnInit {
    * Method invoked when the user drops a tab in this tabbar.
    */
   private onTabbarDrop(): void {
-    const dropIndex = this.dropTargetViewTab === 'end' ? undefined : this._viewTabs.indexOf(this.dropTargetViewTab!);
     this._viewDragService.dispatchViewMoveEvent({
       source: {
         workbenchId: this._dragData!.workbenchId,
@@ -308,7 +307,7 @@ export class PartBarComponent implements OnInit {
       },
       target: {
         workbenchId: this._workbenchId,
-        insertionIndex: dropIndex,
+        position: this.dropTargetViewTab === 'end' ? 'end' : this._viewTabs.indexOf(this.dropTargetViewTab!),
         elementId: this._part.id,
       },
     });

--- a/projects/scion/workbench/src/lib/part/part.component.ts
+++ b/projects/scion/workbench/src/lib/part/part.component.ts
@@ -8,13 +8,12 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {ChangeDetectorRef, Component, ElementRef, HostBinding, inject, Injector, NgZone, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, ElementRef, HostBinding, Inject, inject, Injector, NgZone, OnDestroy, OnInit} from '@angular/core';
 import {combineLatestWith, EMPTY, from, fromEvent, merge, mergeMap, switchMap} from 'rxjs';
 import {ViewDropZoneDirective, WbViewDropEvent} from '../view-dnd/view-drop-zone.directive';
 import {take} from 'rxjs/operators';
 import {ViewDragService} from '../view-dnd/view-drag.service';
 import {ɵWorkbenchPart} from './ɵworkbench-part.model';
-import {ɵWorkbenchService} from '../ɵworkbench.service';
 import {Logger, LoggerNames} from '../logging';
 import {filterArray, mapArray} from '@scion/toolkit/operators';
 import {WorkbenchViewRegistry} from '../view/workbench-view.registry';
@@ -24,6 +23,7 @@ import {PartBarComponent} from './part-bar/part-bar.component';
 import {WorkbenchPortalOutletDirective} from '../portal/workbench-portal-outlet.directive';
 import {ViewPortalPipe} from '../view/view-portal.pipe';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {WORKBENCH_ID} from '../workbench-id';
 
 @Component({
   selector: 'wb-part',
@@ -64,7 +64,7 @@ export class PartComponent implements OnInit, OnDestroy {
     return this.part.active;
   }
 
-  constructor(private _workbenchService: ɵWorkbenchService,
+  constructor(@Inject(WORKBENCH_ID) private _workbenchId: string,
               private _viewRegistry: WorkbenchViewRegistry,
               private _viewDragService: ViewDragService,
               private _injector: Injector,
@@ -90,15 +90,15 @@ export class PartComponent implements OnInit, OnDestroy {
   public onViewDrop(event: WbViewDropEvent): void {
     this._viewDragService.dispatchViewMoveEvent({
       source: {
-        appInstanceId: event.dragData.appInstanceId,
+        workbenchId: event.dragData.workbenchId,
         partId: event.dragData.partId,
         viewId: event.dragData.viewId,
         viewUrlSegments: event.dragData.viewUrlSegments,
       },
       target: {
-        appInstanceId: this._workbenchService.appInstanceId,
+        workbenchId: this._workbenchId,
         elementId: this.part.id,
-        region: event.dropRegion,
+        region: event.dropRegion === 'center' ? undefined : event.dropRegion,
       },
     });
   }

--- a/projects/scion/workbench/src/lib/part/view-context-menu/view-menu.component.ts
+++ b/projects/scion/workbench/src/lib/part/view-context-menu/view-menu.component.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Component, HostBinding, HostListener} from '@angular/core';
+import {Component, HostBinding, HostListener, Injector, runInInjectionContext} from '@angular/core';
 import {OverlayRef} from '@angular/cdk/overlay';
 import {Observable, OperatorFunction} from 'rxjs';
 import {map} from 'rxjs/operators';
@@ -45,7 +45,8 @@ export class ViewMenuComponent {
   public menuItemGroups$: Observable<MenuItemGroups>;
 
   constructor(private _overlayRef: OverlayRef,
-              private _view: ɵWorkbenchView) {
+              private _view: ɵWorkbenchView,
+              private _injector: Injector) {
     this.menuItemGroups$ = this._view.menuItems$.pipe(groupMenuItems());
   }
 
@@ -53,7 +54,7 @@ export class ViewMenuComponent {
     if (menuItem.isDisabled?.()) {
       return;
     }
-    menuItem.onAction();
+    runInInjectionContext(this._injector, () => menuItem.onAction());
     this._overlayRef.dispose();
   }
 

--- a/projects/scion/workbench/src/lib/part/view-context-menu/view-menu.service.ts
+++ b/projects/scion/workbench/src/lib/part/view-context-menu/view-menu.service.ts
@@ -251,8 +251,8 @@ export class ViewMenuService {
         accelerator: config.accelerator,
         group: config.group,
         cssClass: config.cssClass,
-        isDisabled: (): boolean => view.first && view.last,
-        onAction: (): void => void view.move('east').then(),
+        isDisabled: () => view.first && view.last,
+        onAction: () => view.move(view.part.id, {region: 'east'}),
       };
     });
   }
@@ -272,8 +272,8 @@ export class ViewMenuService {
         accelerator: config.accelerator,
         group: config.group,
         cssClass: config.cssClass,
-        isDisabled: (): boolean => view.first && view.last,
-        onAction: (): void => void view.move('west').then(),
+        isDisabled: () => view.first && view.last,
+        onAction: () => view.move(view.part.id, {region: 'west'}),
       };
     });
   }
@@ -293,8 +293,8 @@ export class ViewMenuService {
         accelerator: config.accelerator,
         group: config.group,
         cssClass: config.cssClass,
-        isDisabled: (): boolean => view.first && view.last,
-        onAction: (): void => void view.move('north').then(),
+        isDisabled: () => view.first && view.last,
+        onAction: () => view.move(view.part.id, {region: 'north'}),
       };
     });
   }
@@ -314,15 +314,15 @@ export class ViewMenuService {
         accelerator: config.accelerator,
         group: config.group,
         cssClass: config.cssClass,
-        isDisabled: (): boolean => view.first && view.last,
-        onAction: (): void => void view.move('south').then(),
+        isDisabled: () => view.first && view.last,
+        onAction: () => view.move(view.part.id, {region: 'south'}),
       };
     });
   }
 
   private registerMoveToNewWindowMenuItem(): void {
     const defaults: MenuItemConfig = {visible: true, text: 'Move to new window', group: 'open', cssClass: 'e2e-move-to-new-window'};
-    const appConfig: MenuItemConfig | undefined = this._workbenchModuleConfig.viewMenuItems?.moveBlank;
+    const appConfig: MenuItemConfig | undefined = this._workbenchModuleConfig.viewMenuItems?.moveToNewWindow;
     const config = {...defaults, ...appConfig};
 
     config.visible && this._workbenchService.registerViewMenuItem((view: WorkbenchView): WorkbenchMenuItem => {
@@ -335,7 +335,7 @@ export class ViewMenuService {
         accelerator: config.accelerator,
         group: config.group,
         cssClass: config.cssClass,
-        onAction: (): void => void view.move('blank-window').then(),
+        onAction: () => view.move('new-window'),
       };
     });
   }

--- a/projects/scion/workbench/src/lib/part/view-context-menu/view-menu.service.ts
+++ b/projects/scion/workbench/src/lib/part/view-context-menu/view-menu.service.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {ElementRef, Injectable, Injector} from '@angular/core';
+import {ElementRef, Injectable, Injector, runInInjectionContext} from '@angular/core';
 import {ConnectedPosition, Overlay, OverlayConfig, OverlayRef} from '@angular/cdk/overlay';
 import {ComponentPortal} from '@angular/cdk/portal';
 import {ViewMenuComponent} from './view-menu.component';
@@ -125,7 +125,7 @@ export class ViewMenuService {
           takeUntil(unsubscribe$),
         )
         .subscribe((menuItem: WorkbenchMenuItem) => {
-          menuItem.onAction();
+          runInInjectionContext(this._injector, () => menuItem.onAction());
         });
 
       return (): void => unsubscribe$.next();

--- a/projects/scion/workbench/src/lib/part/view-tab/view-tab.component.ts
+++ b/projects/scion/workbench/src/lib/part/view-tab/view-tab.component.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {Component, ElementRef, HostBinding, HostListener, inject, Injector, Input, IterableChanges, IterableDiffers, NgZone, OnChanges, SimpleChanges} from '@angular/core';
+import {Component, ElementRef, HostBinding, HostListener, Inject, inject, Injector, Input, IterableChanges, IterableDiffers, NgZone, OnChanges, SimpleChanges} from '@angular/core';
 import {fromEvent, merge, Subject, withLatestFrom} from 'rxjs';
 import {WorkbenchViewRegistry} from '../../view/workbench-view.registry';
 import {filter, map, switchMap} from 'rxjs/operators';
@@ -23,9 +23,9 @@ import {ɵWorkbenchView} from '../../view/ɵworkbench-view.model';
 import {WorkbenchView} from '../../view/workbench-view.model';
 import {WorkbenchRouter} from '../../routing/workbench-router.service';
 import {subscribeInside} from '@scion/toolkit/operators';
-import {ɵWorkbenchService} from '../../ɵworkbench.service';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {NgIf} from '@angular/common';
+import {WORKBENCH_ID} from '../../workbench-id';
 
 /**
  * IMPORTANT: HTML and CSS also used by {@link ViewTabDragImageComponent}.
@@ -69,7 +69,7 @@ export class ViewTabComponent implements OnChanges {
   }
 
   constructor(host: ElementRef<HTMLElement>,
-              private _workbenchService: ɵWorkbenchService,
+              @Inject(WORKBENCH_ID) private _workbenchId: string,
               private _workbenchModuleConfig: WorkbenchModuleConfig,
               private _viewRegistry: WorkbenchViewRegistry,
               private _router: WorkbenchRouter,
@@ -154,7 +154,7 @@ export class ViewTabComponent implements OnChanges {
         viewTabPointerOffsetY: event.offsetY,
         viewTabWidth: this.host.getBoundingClientRect().width,
         viewTabHeight: this.host.getBoundingClientRect().height,
-        appInstanceId: this._workbenchService.appInstanceId,
+        workbenchId: this._workbenchId
       });
     });
   }

--- a/projects/scion/workbench/src/lib/public_api.ts
+++ b/projects/scion/workbench/src/lib/public_api.ts
@@ -11,6 +11,7 @@
 export {WorkbenchModuleConfig, MenuItemConfig, ViewMenuItemsConfig} from './workbench-module-config';
 export {WorkbenchModule} from './workbench.module';
 export {WorkbenchService} from './workbench.service';
+export {WORKBENCH_ID} from './workbench-id';
 export {WorkbenchViewPreDestroy, WorkbenchPartAction, WorkbenchTheme, CanMatchPartFn, WorkbenchMenuItem, WorkbenchMenuItemFactoryFn} from './workbench.model';
 export {WorkbenchComponent} from './workbench.component';
 export {VIEW_TAB_RENDERING_CONTEXT, ViewTabRenderingContext} from './workbench.constants';

--- a/projects/scion/workbench/src/lib/routing/workbench-router.service.ts
+++ b/projects/scion/workbench/src/lib/routing/workbench-router.service.ts
@@ -131,14 +131,13 @@ export class WorkbenchRouter implements OnDestroy {
         if (extras.blankPartId && layout.hasPart(extras.blankPartId)) {
           return extras.blankPartId;
         }
-
         return layout.activePart({grid: 'mainArea'})?.id ?? layout.activePart({grid: 'workbench'}).id;
       })();
 
       return {
         layout: layout.addView(viewId, {
           partId,
-          position: layout.computeViewInsertionIndex(extras.blankInsertionIndex, partId),
+          position: extras.blankInsertionIndex ?? 'after-active-view',
           activateView: extras.activate ?? true,
         }),
         viewOutlets: commands.length ? {[viewId]: commands} : {},

--- a/projects/scion/workbench/src/lib/routing/workbench-router.service.ts
+++ b/projects/scion/workbench/src/lib/routing/workbench-router.service.ts
@@ -316,6 +316,10 @@ export class WorkbenchRouter implements OnDestroy {
    * The resulting commands are in their absolute form and may be used for the effective navigation to target a named router outlet.
    */
   private normalizeCommands(commands: Commands, relativeTo?: ActivatedRoute | null): Commands {
+    if (!commands.length) {
+      return [];
+    }
+
     // Ensure to run in Angular zone.
     if (!NgZone.isInAngularZone()) {
       return this._zone.run(() => this.normalizeCommands(commands, relativeTo));

--- a/projects/scion/workbench/src/lib/view-dnd/view-drag.service.ts
+++ b/projects/scion/workbench/src/lib/view-dnd/view-drag.service.ts
@@ -310,9 +310,9 @@ export interface ViewMoveEvent {
      */
     region?: 'north' | 'east' | 'south' | 'west';
     /**
-     * Tab index in the tabbar where to add the view tab. If not set, the view tab is added as last view tab.
+     * Position where to insert the view. The position is zero-based. If not set, adds the view after the active view.
      */
-    insertionIndex?: number;
+    position?: number | 'start' | 'end';
     /**
      * Identifier of the target workbench, or 'new-window' to move the view to a new browser window.
      */

--- a/projects/scion/workbench/src/lib/view-dnd/view-drag.service.ts
+++ b/projects/scion/workbench/src/lib/view-dnd/view-drag.service.ts
@@ -273,7 +273,7 @@ export interface ViewDragData {
   partId: string;
   viewTabWidth: number;
   viewTabHeight: number;
-  appInstanceId: string;
+  workbenchId: string;
 }
 
 /**
@@ -284,15 +284,15 @@ export interface ViewMoveEvent {
     viewId: string;
     partId: string;
     viewUrlSegments: UrlSegment[];
-    appInstanceId: string;
+    workbenchId: string;
   };
   target: {
     /**
      * Part (or node) where (or relative to which) to add the view.
      *
      * Rules for different regions:
-     * - For region 'center', the 'elementId' is mandatory and must reference a part.
-     * - For regions 'north', 'south', 'east', or 'west', the 'elementId' can reference a part or node,
+     * - If not specifying a region, {@link elementId} is mandatory and must reference a part.
+     * - For regions `north`, `south`, `east`, or `west`, {@link elementId} can reference a part or node,
      *   relative to which to align the view. If not set, the view is aligend relative to the root of
      *   the entire layout.
      *
@@ -300,19 +300,23 @@ export interface ViewMoveEvent {
      */
     elementId?: string;
     /**
-     * Region where to add the view. For regions 'north', 'south', 'east', or 'west', creates a new part in that region.
+     * Region of {@link elementId} where to add the view (in a new part).
      *
-     * Note: Property is ignored when moving the view to a new window. If not set, it defaults to 'center'.
+     * If not specified, {@link elementId} must reference a part to which to add the view.
+     *
+     * Note:
+     * - Property is ignored when moving the view to a new window.
+     * - Property is required if {@link elementId} is a node.
      */
-    region?: 'north' | 'east' | 'south' | 'west' | 'center';
+    region?: 'north' | 'east' | 'south' | 'west';
     /**
      * Tab index in the tabbar where to add the view tab. If not set, the view tab is added as last view tab.
      */
     insertionIndex?: number;
     /**
-     * Identifier of the target application, or 'new' to move the view to a new browser window.
+     * Identifier of the target workbench, or 'new-window' to move the view to a new browser window.
      */
-    appInstanceId: string | 'new';
+    workbenchId: string | 'new-window';
     /**
      * Describes the part to be created if the region is 'north', 'east', 'south', or 'west'.
      */

--- a/projects/scion/workbench/src/lib/view-dnd/view-tab-drag-image-renderer.service.ts
+++ b/projects/scion/workbench/src/lib/view-dnd/view-tab-drag-image-renderer.service.ts
@@ -257,7 +257,7 @@ class DragImageWorkbenchView implements WorkbenchView {
     throw Error('[UnsupportedOperationError]');
   }
 
-  public move(region: 'north' | 'south' | 'west' | 'east'): Promise<boolean> {
+  public move(target: 'new-window' | string, options?: {region?: 'north' | 'south' | 'west' | 'east'; workbenchId?: string}): void {
     throw Error('[UnsupportedOperationError]');
   }
 

--- a/projects/scion/workbench/src/lib/view/view-move-handler.service.ts
+++ b/projects/scion/workbench/src/lib/view/view-move-handler.service.ts
@@ -81,7 +81,7 @@ export class ViewMoveHandler {
         return {
           layout: layout.addView(newViewId, {
             partId: Defined.orElseThrow(event.target.elementId, () => Error(`[IllegalArgumentError] Target part mandatory for region 'center'.`)),
-            position: event.target.insertionIndex,
+            position: event.target.position ?? 'after-active-view',
             activateView: true,
             activatePart: true,
           }),
@@ -145,7 +145,7 @@ export class ViewMoveHandler {
     else {
       const targetPartId = Defined.orElseThrow(event.target.elementId, () => Error(`[IllegalArgumentError] Target part mandatory for region 'center'.`));
       await this._workbenchRouter.ɵnavigate(layout => layout.moveView(event.source.viewId, targetPartId, {
-        position: event.target.insertionIndex,
+        position: event.target.position ?? (event.source.partId === targetPartId ? undefined : 'after-active-view'),
         activateView: true,
         activatePart: true,
       }));

--- a/projects/scion/workbench/src/lib/view/workbench-view.model.ts
+++ b/projects/scion/workbench/src/lib/view/workbench-view.model.ts
@@ -125,9 +125,17 @@ export abstract class WorkbenchView {
   public abstract close(target?: 'self' | 'all-views' | 'other-views' | 'views-to-the-right' | 'views-to-the-left'): Promise<boolean>;
 
   /**
-   * Moves this view to a new part in the specified region, or to a new browser window if 'blank-window'.
+   * Moves this view to a new browser window.
    */
-  public abstract move(region: 'north' | 'south' | 'west' | 'east' | 'blank-window'): Promise<boolean>;
+  public abstract move(target: 'new-window'): void;
+
+  /**
+   * Moves this view to a different or new part in the specified region.
+   *
+   * Specifying a target workbench identifier allows the view to be moved to a workbench in a different browser window.
+   * The target workbench ID is available via {@link WORKBENCH_ID} DI token in the target application.
+   */
+  public abstract move(partId: string, options?: {region?: 'north' | 'south' | 'west' | 'east'; workbenchId?: string}): void;
 
   /**
    * Registers a menu item which is added to the context menu of the view tab.

--- a/projects/scion/workbench/src/lib/workbench-id.ts
+++ b/projects/scion/workbench/src/lib/workbench-id.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018-2024 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {InjectionToken} from '@angular/core';
+import {UUID} from '@scion/toolkit/uuid';
+
+/**
+ * DI token to get a unique id of the workbench.
+ *
+ * The id is different each time the app is reloaded. Different workbench windows have different ids.
+ */
+export const WORKBENCH_ID = new InjectionToken<string>('WORKBENCH_ID', {
+  providedIn: 'root',
+  factory: () => UUID.randomUUID(),
+});

--- a/projects/scion/workbench/src/lib/workbench-module-config.ts
+++ b/projects/scion/workbench/src/lib/workbench-module-config.ts
@@ -198,7 +198,7 @@ export interface ViewMenuItemsConfig {
   moveRight?: MenuItemConfig;
   moveDown?: MenuItemConfig;
   moveLeft?: MenuItemConfig;
-  moveBlank?: MenuItemConfig;
+  moveToNewWindow?: MenuItemConfig;
 }
 
 export interface MenuItemConfig {

--- a/projects/scion/workbench/src/lib/workbench.model.ts
+++ b/projects/scion/workbench/src/lib/workbench.model.ts
@@ -79,7 +79,9 @@ export interface WorkbenchMenuItem {
    */
   portal: TemplatePortal | ComponentPortal<any>;
   /**
-   * Sets the listener invoked when the user performs the menu action, either by clicking the menu or via keyboard accelerator, if any.
+   * Specifies the callback triggered when clicking this menu item.
+   *
+   * The function can call `inject` to get any required dependencies.
    */
   onAction: () => void;
   /**

--- a/projects/scion/workbench/src/lib/ɵworkbench.service.ts
+++ b/projects/scion/workbench/src/lib/ɵworkbench.service.ts
@@ -11,7 +11,6 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {WorkbenchMenuItemFactoryFn, WorkbenchPartAction, WorkbenchTheme} from './workbench.model';
-import {UUID} from '@scion/toolkit/uuid';
 import {Disposable} from './common/disposable';
 import {WorkbenchService} from './workbench.service';
 import {WorkbenchRouter} from './routing/workbench-router.service';
@@ -28,11 +27,6 @@ import {WorkbenchThemeSwitcher} from './theme/workbench-theme-switcher.service';
 
 @Injectable({providedIn: 'root'})
 export class ɵWorkbenchService implements WorkbenchService {
-
-  /**
-   * A unique ID per instance of the app. If opened in a different browser tab, it has a different instance ID.
-   */
-  public readonly appInstanceId = UUID.randomUUID();
 
   public readonly perspectives$: Observable<readonly ɵWorkbenchPerspective[]>;
   public readonly parts$: Observable<readonly ɵWorkbenchPart[]>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: Support for programmatically moving view to different workbench window has introduced a breaking change.

The signature of `WorkbenchView#move` has changed.

To migrate:
- Specify the target part as the first argument, optionally defining the region via options object.
- Use 'new_window' instead of 'blank-window' to move the view to a new window.
- To move a view to another workbench window, pass the workbench id via options object.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
