### PR TITLE
fix(workbench): render tab content when dragging view quickly into the window

### DIFF
--- a/projects/scion/workbench/src/lib/view-dnd/view-tab-drag-image-renderer.service.ts
+++ b/projects/scion/workbench/src/lib/view-dnd/view-tab-drag-image-renderer.service.ts
@@ -132,13 +132,15 @@ export class ViewTabDragImageRenderer {
       },
     });
     this._viewDragImagePortalOutlet = new DomPortalOutlet(outletElement, this._componentFactoryResolver, this._applicationRef, this._injector);
-    this._viewDragImagePortalOutlet.attachComponentPortal(new ComponentPortal(ViewTabDragImageComponent, null, Injector.create({
+    const componentRef = this._viewDragImagePortalOutlet.attachComponentPortal(new ComponentPortal(ViewTabDragImageComponent, null, Injector.create({
       parent: this._injector,
       providers: [
         {provide: WorkbenchView, useValue: new DragImageWorkbenchView(dragData)},
         {provide: VIEW_TAB_RENDERING_CONTEXT, useValue: 'drag-image' satisfies ViewTabRenderingContext},
       ],
     })));
+    // Detect for changes because constructed outside of Angular.
+    componentRef.changeDetectorRef.detectChanges();
   }
 
   private disposeDragImage(): void {


### PR DESCRIPTION
The drag image is constructed outside the Angular zone. Without manually detecting the drag image for changes, the tab content would not render before the next Angular app tick.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
