### PR TITLE
feat(workbench/popup): support returning result on focus loss

### DIFF
--- a/apps/workbench-client-testing-app/src/app/popup-page/popup-page.component.html
+++ b/apps/workbench-client-testing-app/src/app/popup-page/popup-page.component.html
@@ -126,12 +126,16 @@
       </ng-template>
       <ng-template #panel_return_value>
         <input [formControl]="form.controls.result" class="e2e-return-value" placeholder="Optional data to return to the popup opener">
+        <button (click)="onApplyReturnValue()" class="e2e-apply-return-value">Apply</button>
       </ng-template>
     </sci-accordion>
   </form>
 </sci-viewport>
 
 <div class="buttons">
+  <label class="close-with-error">
+    <sci-checkbox [formControl]="form.controls.closeWithError" class="e2e-close-with-error"/>
+    Close with error
+  </label>
   <button (click)="onClose()" class="e2e-close" sci-primary>Close</button>
-  <button (click)="onCloseWithError()" class="e2e-close-with-error">Close (with error)</button>
 </div>

--- a/apps/workbench-client-testing-app/src/app/popup-page/popup-page.component.scss
+++ b/apps/workbench-client-testing-app/src/app/popup-page/popup-page.component.scss
@@ -81,9 +81,16 @@
 
   > div.buttons {
     flex: none;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    column-gap: .25em;
-    margin-top: 1em;
+    display: flex;
+    gap: 2em;
+    padding-top: 1em;
+    align-items: center;
+    justify-content: space-between;
+
+    > label.close-with-error {
+      display: flex;
+      align-items: center;
+      gap: .5em;
+    }
   }
 }

--- a/apps/workbench-client-testing-app/src/app/popup-page/popup-page.component.ts
+++ b/apps/workbench-client-testing-app/src/app/popup-page/popup-page.component.ts
@@ -22,6 +22,7 @@ import {A11yModule} from '@angular/cdk/a11y';
 import {SciKeyValueComponent} from '@scion/components.internal/key-value';
 import {SciFormFieldComponent} from '@scion/components.internal/form-field';
 import {SciAccordionComponent, SciAccordionItemDirective} from '@scion/components.internal/accordion';
+import {SciCheckboxComponent} from '@scion/components.internal/checkbox';
 
 /**
  * Popup test component which can grow and shrink.
@@ -43,6 +44,7 @@ import {SciAccordionComponent, SciAccordionItemDirective} from '@scion/component
     SciAccordionItemDirective,
     SciKeyValueComponent,
     ReactiveFormsModule,
+    SciCheckboxComponent,
   ],
 })
 export default class PopupPageComponent {
@@ -91,6 +93,7 @@ export default class PopupPageComponent {
     minWidth: this._formBuilder.control('100vw'),
     width: this._formBuilder.control(''),
     maxWidth: this._formBuilder.control(''),
+    closeWithError: this._formBuilder.control(false),
     result: this._formBuilder.control(''),
   });
 
@@ -107,11 +110,12 @@ export default class PopupPageComponent {
     popup.signalReady();
   }
 
-  public onClose(): void {
-    this.popup.close(this.form.controls.result.value);
+  protected onApplyReturnValue(): void {
+    this.popup.setResult(this.form.controls.result.value);
   }
 
-  public onCloseWithError(): void {
-    this.popup.closeWithError(this.form.controls.result.value);
+  protected onClose(): void {
+    const result = this.form.controls.closeWithError.value ? new Error(this.form.controls.result.value) : this.form.controls.result.value;
+    this.popup.close(result);
   }
 }

--- a/apps/workbench-testing-app/src/app/host-popup-page/host-popup-page.component.html
+++ b/apps/workbench-testing-app/src/app/host-popup-page/host-popup-page.component.html
@@ -104,12 +104,16 @@
       </ng-template>
       <ng-template #panel_return_value>
         <input [formControl]="form.controls.result" class="e2e-return-value" placeholder="Optional data to return to the popup opener">
+        <button (click)="onApplyReturnValue()" class="e2e-apply-return-value">Apply</button>
       </ng-template>
     </sci-accordion>
   </form>
 </sci-viewport>
 
 <div class="buttons">
-  <button (click)="onClose()" class="e2e-close">Close</button>
-  <button (click)="onCloseWithError()" class="e2e-close-with-error">Close (with error)</button>
+  <label class="close-with-error">
+    <sci-checkbox [formControl]="form.controls.closeWithError" class="e2e-close-with-error"/>
+    Close with error
+  </label>
+  <button (click)="onClose()" class="e2e-close" sci-primary>Close</button>
 </div>

--- a/apps/workbench-testing-app/src/app/host-popup-page/host-popup-page.component.scss
+++ b/apps/workbench-testing-app/src/app/host-popup-page/host-popup-page.component.scss
@@ -77,9 +77,16 @@
 
   > div.buttons {
     flex: none;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    column-gap: .25em;
-    margin-top: 1em;
+    display: flex;
+    gap: 2em;
+    padding-top: 1em;
+    align-items: center;
+    justify-content: space-between;
+
+    > label.close-with-error {
+      display: flex;
+      align-items: center;
+      gap: .5em;
+    }
   }
 }

--- a/apps/workbench-testing-app/src/app/host-popup-page/host-popup-page.component.ts
+++ b/apps/workbench-testing-app/src/app/host-popup-page/host-popup-page.component.ts
@@ -20,6 +20,7 @@ import {NullIfEmptyPipe} from '../common/null-if-empty.pipe';
 import {SciKeyValueComponent} from '@scion/components.internal/key-value';
 import {SciFormFieldComponent} from '@scion/components.internal/form-field';
 import {SciAccordionComponent, SciAccordionItemDirective} from '@scion/components.internal/accordion';
+import {SciCheckboxComponent} from '@scion/components.internal/checkbox';
 
 /**
  * Popup component provided by the host app via a popup capability.
@@ -41,6 +42,7 @@ import {SciAccordionComponent, SciAccordionItemDirective} from '@scion/component
     SciAccordionItemDirective,
     SciKeyValueComponent,
     ReactiveFormsModule,
+    SciCheckboxComponent,
   ],
 })
 export default class HostPopupPageComponent {
@@ -84,6 +86,7 @@ export default class HostPopupPageComponent {
     minWidth: this._formBuilder.control(''),
     width: this._formBuilder.control(''),
     maxWidth: this._formBuilder.control(''),
+    closeWithError: this._formBuilder.control(false),
     result: this._formBuilder.control(''),
   });
 
@@ -92,11 +95,12 @@ export default class HostPopupPageComponent {
               private _formBuilder: NonNullableFormBuilder) {
   }
 
-  public onClose(): void {
-    this.popup.close(this.form.controls.result.value);
+  protected onApplyReturnValue(): void {
+    this.popup.setResult(this.form.controls.result.value);
   }
 
-  public onCloseWithError(): void {
-    this.popup.closeWithError(this.form.controls.result.value);
+  protected onClose(): void {
+    const result = this.form.controls.closeWithError.value ? new Error(this.form.controls.result.value) : this.form.controls.result.value;
+    this.popup.close(result);
   }
 }

--- a/apps/workbench-testing-app/src/app/popup-page/popup-page.component.html
+++ b/apps/workbench-testing-app/src/app/popup-page/popup-page.component.html
@@ -60,12 +60,16 @@
       </ng-template>
       <ng-template #panel_return_value>
         <input class="e2e-return-value" [formControl]="form.controls.result" placeholder="Optional data to return to the popup opener">
+        <button (click)="onApplyReturnValue()" class="e2e-apply-return-value">Apply</button>
       </ng-template>
     </sci-accordion>
   </form>
 </sci-viewport>
 
 <div class="buttons">
+  <label class="close-with-error">
+    <sci-checkbox [formControl]="form.controls.closeWithError" class="e2e-close-with-error"/>
+    Close with error
+  </label>
   <button (click)="onClose()" class="e2e-close" sci-primary>Close</button>
-  <button (click)="onCloseWithError()" class="e2e-close-with-error">Close (with error)</button>
 </div>

--- a/apps/workbench-testing-app/src/app/popup-page/popup-page.component.scss
+++ b/apps/workbench-testing-app/src/app/popup-page/popup-page.component.scss
@@ -41,9 +41,16 @@
 
   > div.buttons {
     flex: none;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    column-gap: .25em;
-    margin-top: 1em;
+    display: flex;
+    gap: 1em;
+    padding-top: 1em;
+    align-items: center;
+    justify-content: space-between;
+
+    > label.close-with-error {
+      display: flex;
+      align-items: center;
+      gap: .5em;
+    }
   }
 }

--- a/apps/workbench-testing-app/src/app/popup-page/popup-page.component.ts
+++ b/apps/workbench-testing-app/src/app/popup-page/popup-page.component.ts
@@ -17,6 +17,7 @@ import {NullIfEmptyPipe} from '../common/null-if-empty.pipe';
 import {JsonPipe} from '@angular/common';
 import {SciFormFieldComponent} from '@scion/components.internal/form-field';
 import {SciAccordionComponent, SciAccordionItemDirective} from '@scion/components.internal/accordion';
+import {SciCheckboxComponent} from '@scion/components.internal/checkbox';
 
 @Component({
   selector: 'app-popup-page',
@@ -32,6 +33,7 @@ import {SciAccordionComponent, SciAccordionItemDirective} from '@scion/component
     SciAccordionComponent,
     SciAccordionItemDirective,
     ReactiveFormsModule,
+    SciCheckboxComponent,
   ],
 })
 export class PopupPageComponent {
@@ -75,17 +77,19 @@ export class PopupPageComponent {
     minWidth: this._formBuilder.control(''),
     width: this._formBuilder.control(''),
     maxWidth: this._formBuilder.control(''),
+    closeWithError: this._formBuilder.control(false),
     result: this._formBuilder.control(''),
   });
 
   constructor(public popup: Popup, private _formBuilder: NonNullableFormBuilder) {
   }
 
-  public onClose(): void {
-    this.popup.close(this.form.controls.result.value);
+  protected onApplyReturnValue(): void {
+    this.popup.setResult(this.form.controls.result.value);
   }
 
-  public onCloseWithError(): void {
-    this.popup.closeWithError(this.form.controls.result.value);
+  protected onClose(): void {
+    const result = this.form.controls.closeWithError.value ? new Error(this.form.controls.result.value) : this.form.controls.result.value;
+    this.popup.close(result);
   }
 }

--- a/docs/site/howto/how-to-open-popup.md
+++ b/docs/site/howto/how-to-open-popup.md
@@ -24,7 +24,7 @@ const result = await popupService.open({
 });
 ```
 
-To interact with the popup in the popup component, inject the popup handle `Popup`, e.g., to close the popup or read input passed to the popup by the popup opener.
+To interact with the popup in the popup component, inject the popup handle `Popup`, e.g., to read input passed to the popup or to close the popup, optionally passing a result to the popup opener.
 
 
 ```typescript

--- a/projects/scion/e2e-testing/src/workbench-client/host-popup.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/host-popup.e2e-spec.ts
@@ -39,46 +39,114 @@ test.describe('Workbench Host Popup', () => {
     await expectPopup(popupPage).toBeVisible();
   });
 
-  test('should allow closing the popup and returning a value to the popup opener', async ({appPO, microfrontendNavigator}) => {
-    await appPO.navigateTo({microfrontendSupport: true});
+  test.describe('popup result', () => {
+    test('should allow closing the popup and returning a value to the popup opener', async ({appPO, microfrontendNavigator}) => {
+      await appPO.navigateTo({microfrontendSupport: true});
 
-    // TODO [#271]: Register popup capability in the host app via RegisterWorkbenchCapabilityPagePO when implemented the issue #271
-    // https://github.com/SchweizerischeBundesbahnen/scion-workbench/issues/271
+      // TODO [#271]: Register popup capability in the host app via RegisterWorkbenchCapabilityPagePO when implemented the issue #271
+      // https://github.com/SchweizerischeBundesbahnen/scion-workbench/issues/271
 
-    await microfrontendNavigator.registerIntention('app1', {type: 'popup', qualifier: {component: 'host-popup'}});
+      await microfrontendNavigator.registerIntention('app1', {type: 'popup', qualifier: {component: 'host-popup'}});
 
-    // open the popup
-    const popupOpenerPage = await microfrontendNavigator.openInNewTab(PopupOpenerPagePO, 'app1');
-    await popupOpenerPage.enterQualifier({component: 'host-popup'});
-    await popupOpenerPage.enterCssClass('testee');
-    await popupOpenerPage.open();
+      // open the popup
+      const popupOpenerPage = await microfrontendNavigator.openInNewTab(PopupOpenerPagePO, 'app1');
+      await popupOpenerPage.enterQualifier({component: 'host-popup'});
+      await popupOpenerPage.enterCssClass('testee');
+      await popupOpenerPage.open();
 
-    const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new HostPopupPagePO(popup);
+      const popup = appPO.popup({cssClass: 'testee'});
+      const popupPage = new HostPopupPagePO(popup);
 
-    await popupPage.close({returnValue: 'RETURN VALUE'});
-    await expect(popupOpenerPage.returnValue).toHaveText('RETURN VALUE');
-  });
+      await popupPage.close({returnValue: 'RETURN VALUE'});
+      await expect(popupOpenerPage.returnValue).toHaveText('RETURN VALUE');
+    });
 
-  test('should allow closing the popup with an error', async ({appPO, microfrontendNavigator}) => {
-    await appPO.navigateTo({microfrontendSupport: true});
+    test('should allow closing the popup with an error', async ({appPO, microfrontendNavigator}) => {
+      await appPO.navigateTo({microfrontendSupport: true});
 
-    // TODO [#271]: Register popup capability in the host app via RegisterWorkbenchCapabilityPagePO when implemented the issue #271
-    // https://github.com/SchweizerischeBundesbahnen/scion-workbench/issues/271
+      // TODO [#271]: Register popup capability in the host app via RegisterWorkbenchCapabilityPagePO when implemented the issue #271
+      // https://github.com/SchweizerischeBundesbahnen/scion-workbench/issues/271
 
-    await microfrontendNavigator.registerIntention('app1', {type: 'popup', qualifier: {component: 'host-popup'}});
+      await microfrontendNavigator.registerIntention('app1', {type: 'popup', qualifier: {component: 'host-popup'}});
 
-    // open the popup
-    const popupOpenerPage = await microfrontendNavigator.openInNewTab(PopupOpenerPagePO, 'app1');
-    await popupOpenerPage.enterQualifier({component: 'host-popup'});
-    await popupOpenerPage.enterCssClass('testee');
-    await popupOpenerPage.open();
+      // open the popup
+      const popupOpenerPage = await microfrontendNavigator.openInNewTab(PopupOpenerPagePO, 'app1');
+      await popupOpenerPage.enterQualifier({component: 'host-popup'});
+      await popupOpenerPage.enterCssClass('testee');
+      await popupOpenerPage.open();
 
-    const popup = appPO.popup({cssClass: 'testee'});
-    const popupPage = new HostPopupPagePO(popup);
+      const popup = appPO.popup({cssClass: 'testee'});
+      const popupPage = new HostPopupPagePO(popup);
 
-    await popupPage.close({returnValue: 'ERROR', closeWithError: true});
-    await expect(popupOpenerPage.error).toHaveText('ERROR');
+      await popupPage.close({returnValue: 'ERROR', closeWithError: true});
+      await expect(popupOpenerPage.error).toHaveText('ERROR');
+    });
+
+    test('should allow returning value on focus loss', async ({appPO, microfrontendNavigator}) => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      // TODO [#271]: Register popup capability in the host app via RegisterWorkbenchCapabilityPagePO when implemented the issue #271
+      // https://github.com/SchweizerischeBundesbahnen/scion-workbench/issues/271
+
+      await microfrontendNavigator.registerIntention('app1', {type: 'popup', qualifier: {component: 'host-popup'}});
+
+      // open the popup
+      const popupOpenerPage = await microfrontendNavigator.openInNewTab(PopupOpenerPagePO, 'app1');
+      await popupOpenerPage.enterQualifier({component: 'host-popup'});
+      await popupOpenerPage.enterCssClass('testee');
+      await popupOpenerPage.open();
+
+      const popup = appPO.popup({cssClass: 'testee'});
+      const popupPage = new HostPopupPagePO(popup);
+      await popupPage.enterReturnValue('RETURN VALUE', {apply: true});
+
+      await popupOpenerPage.view.tab.click();
+      await expect(popupOpenerPage.returnValue).toHaveText('RETURN VALUE');
+    });
+
+    test('should return only the latest result value on close', async ({appPO, microfrontendNavigator}) => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      // TODO [#271]: Register popup capability in the host app via RegisterWorkbenchCapabilityPagePO when implemented the issue #271
+      // https://github.com/SchweizerischeBundesbahnen/scion-workbench/issues/271
+
+      await microfrontendNavigator.registerIntention('app1', {type: 'popup', qualifier: {component: 'host-popup'}});
+
+      // open the popup
+      const popupOpenerPage = await microfrontendNavigator.openInNewTab(PopupOpenerPagePO, 'app1');
+      await popupOpenerPage.enterQualifier({component: 'host-popup'});
+      await popupOpenerPage.enterCssClass('testee');
+      await popupOpenerPage.open();
+
+      const popup = appPO.popup({cssClass: 'testee'});
+      const popupPage = new HostPopupPagePO(popup);
+      await popupPage.enterReturnValue('RETURN VALUE 1', {apply: true});
+
+      await popupPage.close({returnValue: 'RETURN VALUE 2'});
+      await expect(popupOpenerPage.returnValue).toHaveText('RETURN VALUE 2');
+    });
+
+    test('should not return value on escape keystroke', async ({appPO, microfrontendNavigator, page}) => {
+      await appPO.navigateTo({microfrontendSupport: true});
+
+      // TODO [#271]: Register popup capability in the host app via RegisterWorkbenchCapabilityPagePO when implemented the issue #271
+      // https://github.com/SchweizerischeBundesbahnen/scion-workbench/issues/271
+
+      await microfrontendNavigator.registerIntention('app1', {type: 'popup', qualifier: {component: 'host-popup'}});
+
+      // open the popup
+      const popupOpenerPage = await microfrontendNavigator.openInNewTab(PopupOpenerPagePO, 'app1');
+      await popupOpenerPage.enterQualifier({component: 'host-popup'});
+      await popupOpenerPage.enterCssClass('testee');
+      await popupOpenerPage.open();
+
+      const popup = appPO.popup({cssClass: 'testee'});
+      const popupPage = new HostPopupPagePO(popup);
+      await popupPage.enterReturnValue('RETURN VALUE', {apply: true});
+
+      await page.keyboard.press('Escape');
+      await expect(popupOpenerPage.returnValue).not.toBeAttached();
+    });
   });
 
   test('should stick to the popup anchor', async ({appPO, microfrontendNavigator}) => {

--- a/projects/scion/e2e-testing/src/workbench-client/page-object/host-popup-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/page-object/host-popup-page.po.ts
@@ -17,6 +17,7 @@ import {SciAccordionPO} from '../../@scion/components.internal/accordion.po';
 import {SciKeyValuePO} from '../../@scion/components.internal/key-value.po';
 import {Locator} from '@playwright/test';
 import {WorkbenchPopupPagePO} from '../../workbench/page-object/workbench-popup-page.po';
+import {SciCheckboxPO} from '../../@scion/components.internal/checkbox.po';
 
 /**
  * Page object to interact with {@link HostPopupPageComponent}.
@@ -92,11 +93,15 @@ export class HostPopupPagePO implements WorkbenchPopupPagePO {
     await this.locator.locator('input.e2e-max-height').fill(size.maxHeight ?? '');
   }
 
-  public async enterReturnValue(returnValue: string): Promise<void> {
+  public async enterReturnValue(returnValue: string, options?: {apply?: boolean}): Promise<void> {
     const accordion = new SciAccordionPO(this.locator.locator('sci-accordion.e2e-return-value'));
     await accordion.expand();
     try {
       await accordion.itemLocator().locator('input.e2e-return-value').fill(returnValue);
+
+      if (options?.apply) {
+        await this.locator.locator('button.e2e-apply-return-value').click();
+      }
     }
     finally {
       await accordion.collapse();
@@ -108,11 +113,10 @@ export class HostPopupPagePO implements WorkbenchPopupPagePO {
       await this.enterReturnValue(options.returnValue);
     }
 
-    if (options?.closeWithError === true) {
-      await this.locator.locator('button.e2e-close-with-error').click();
+    if (options?.closeWithError) {
+      await new SciCheckboxPO(this.locator.locator('sci-checkbox.e2e-close-with-error')).toggle(true);
     }
-    else {
-      await this.locator.locator('button.e2e-close').click();
-    }
+
+    await this.locator.locator('button.e2e-close').click();
   }
 }

--- a/projects/scion/e2e-testing/src/workbench-client/page-object/popup-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/page-object/popup-page.po.ts
@@ -19,6 +19,7 @@ import {SciKeyValuePO} from '../../@scion/components.internal/key-value.po';
 import {SciRouterOutletPO} from './sci-router-outlet.po';
 import {MicrofrontendPopupPagePO} from '../../workbench/page-object/workbench-popup-page.po';
 import {AppPO} from '../../app.po';
+import {SciCheckboxPO} from '../../@scion/components.internal/checkbox.po';
 
 /**
  * Page object to interact with {@link PopupPageComponent}.
@@ -117,11 +118,15 @@ export class PopupPagePO implements MicrofrontendPopupPagePO {
     await this.locator.locator('input.e2e-max-height').fill(size.maxHeight ?? '');
   }
 
-  public async enterReturnValue(returnValue: string): Promise<void> {
+  public async enterReturnValue(returnValue: string, options?: {apply?: boolean}): Promise<void> {
     const accordion = new SciAccordionPO(this.locator.locator('sci-accordion.e2e-return-value'));
     await accordion.expand();
     try {
       await accordion.itemLocator().locator('input.e2e-return-value').fill(returnValue);
+
+      if (options?.apply) {
+        await this.locator.locator('button.e2e-apply-return-value').click();
+      }
     }
     finally {
       await accordion.collapse();
@@ -134,11 +139,10 @@ export class PopupPagePO implements MicrofrontendPopupPagePO {
     }
 
     if (options?.closeWithError) {
-      await this.locator.locator('button.e2e-close-with-error').click();
+      await new SciCheckboxPO(this.locator.locator('sci-checkbox.e2e-close-with-error')).toggle(true);
     }
-    else {
-      await this.locator.locator('button.e2e-close').click();
-    }
+
+    await this.locator.locator('button.e2e-close').click();
   }
 
   /**

--- a/projects/scion/e2e-testing/src/workbench/page-object/popup-page.po.ts
+++ b/projects/scion/e2e-testing/src/workbench/page-object/popup-page.po.ts
@@ -14,6 +14,7 @@ import {PopupReferrer, PopupSize} from '@scion/workbench';
 import {SciAccordionPO} from '../../@scion/components.internal/accordion.po';
 import {Locator} from '@playwright/test';
 import {WorkbenchPopupPagePO} from './workbench-popup-page.po';
+import {SciCheckboxPO} from '../../@scion/components.internal/checkbox.po';
 
 /**
  * Page object to interact with {@link PopupPageComponent}.
@@ -47,18 +48,21 @@ export class PopupPagePO implements WorkbenchPopupPagePO {
     }
 
     if (options?.closeWithError) {
-      await this.locator.locator('button.e2e-close-with-error').click();
+      await new SciCheckboxPO(this.locator.locator('sci-checkbox.e2e-close-with-error')).toggle(true);
     }
-    else {
-      await this.locator.locator('button.e2e-close').click();
-    }
+
+    await this.locator.locator('button.e2e-close').click();
   }
 
-  public async enterReturnValue(returnValue: string): Promise<void> {
+  public async enterReturnValue(returnValue: string, options?: {apply?: boolean}): Promise<void> {
     const accordion = new SciAccordionPO(this.locator.locator('sci-accordion.e2e-return-value'));
     await accordion.expand();
     try {
       await accordion.itemLocator().locator('input.e2e-return-value').fill(returnValue);
+
+      if (options?.apply) {
+        await this.locator.locator('button.e2e-apply-return-value').click();
+      }
     }
     finally {
       await accordion.collapse();

--- a/projects/scion/workbench-client/src/lib/popup/workbench-popup.config.ts
+++ b/projects/scion/workbench-client/src/lib/popup/workbench-popup.config.ts
@@ -83,14 +83,13 @@ export interface WorkbenchPopupConfig {
  */
 export interface CloseStrategy {
   /**
-   * If `true`, which is by default, will close the popup on focus loss.
-   * No return value will be passed to the popup opener.
+   * Controls if to close the popup on focus loss, returning the result set via {@link Popup#setResult} to the popup opener.
+   * Defaults to `true`.
    */
   onFocusLost?: boolean;
   /**
-   * If `true`, which is by default, will close the popup when the user
-   * hits the escape key. No return value will be passed to the popup
-   * opener.
+   * Controls if to close the popup when pressing escape. Defaults to `true`.
+   * No return value will be passed to the popup opener.
    */
   onEscape?: boolean;
 }

--- a/projects/scion/workbench-client/src/lib/ɵworkbench-commands.ts
+++ b/projects/scion/workbench-client/src/lib/ɵworkbench-commands.ts
@@ -102,6 +102,11 @@ export const ɵWorkbenchCommands = {
   popupCloseTopic: (popupId: string) => `ɵworkbench/popups/${popupId}/close`,
 
   /**
+   * Computes the topic via which to set a result
+   */
+  popupResultTopic: (popupId: string) => `ɵworkbench/popups/${popupId}/result`,
+
+  /**
    * Computes the topic via which the title of a dialog can be set.
    */
   dialogTitleTopic: (dialogId: string) => `ɵworkbench/dialogs/${dialogId}/title`,

--- a/projects/scion/workbench/src/lib/microfrontend-platform/microfrontend-host-popup/microfrontend-host-popup.component.ts
+++ b/projects/scion/workbench/src/lib/microfrontend-platform/microfrontend-host-popup/microfrontend-host-popup.component.ts
@@ -61,7 +61,7 @@ export class MicrofrontendHostPopupComponent implements OnDestroy {
     // Perform navigation in the named router outlet.
     this.navigate(path, {outletName: this.outletName, params}).then(success => {
       if (!success) {
-        popup.closeWithError(Error('[PopupNavigateError] Navigation canceled, most likely by a route guard or a parallel navigation.'));
+        popup.close(Error('[PopupNavigateError] Navigation canceled, most likely by a route guard or a parallel navigation.'));
       }
     });
   }
@@ -91,17 +91,17 @@ function provideWorkbenchPopupHandle(popupContext: ɵPopupContext): StaticProvid
     useFactory: (): WorkbenchPopup => {
       const popup = inject(Popup);
 
-      return new class implements WorkbenchPopup {
+      return new class<R = unknown> implements WorkbenchPopup {
         public readonly capability = popupContext.capability;
         public readonly params = popupContext.params;
         public readonly referrer = popupContext.referrer;
 
-        public close<R = any>(result?: R | undefined): void {
-          popup.close(result);
+        public setResult(result?: R): void {
+          popup.setResult(result);
         }
 
-        public closeWithError(error: Error | string): void {
-          popup.closeWithError(error);
+        public close(result?: R | Error): void {
+          popup.close(result);
         }
 
         public signalReady(): void {


### PR DESCRIPTION
A result can be set on the popup handle that will be returned to the popup opener on focus loss.

```ts
import {inject} from '@angular/core';
import {Popup} from '@scion/workbench';

inject(Popup).setResult('result');
```

BREAKING CHANGE: The method `closeWithError` has been removed from the `Popup` handle. Instead, pass an `Error` object to the `close` method.

**Before migration:**
```ts
import {inject} from '@angular/core';
import {Popup} from '@scion/workbench';

inject(Popup).closeWithError('some error');
```

**After migration:**
```ts
import {inject} from '@angular/core';
import {Popup} from '@scion/workbench';

inject(Popup).close(new Error('some error'));
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
See commit message
