### PR TITLE
Issue/sub domain

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -344,8 +344,8 @@ jobs:
           project-id: ${{ secrets.VERCEL_WORKBENCH_CLIENT_API_PROJECT_ID }}
           version: ${{ needs.build-libs.outputs.workbench-client-version }}
           aliases: |
-            scion-workbench-client-api.vercel.app,
-            scion-workbench-client-api-v%v.vercel.app
+            workbench-client-api.scion.vercel.app,
+            workbench-client-api-v%v.scion.vercel.app
       - name: 'Publishing @scion/workbench-client to NPM'
         uses: SchweizerischeBundesbahnen/scion-toolkit/.github/actions/npm-publish@master
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -272,7 +272,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_WORKBENCH_TESTING_APP_PROJECT_ID }}
-          aliases: scion-workbench-testing-app.vercel.app
+          aliases: workbench-testing-app.scion.vercel.app
       - name: 'Deploying workbench-client-testing-app to Vercel'
         uses: SchweizerischeBundesbahnen/scion-toolkit/.github/actions/vercel-deploy@master
         with:
@@ -281,8 +281,8 @@ jobs:
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_WORKBENCH_CLIENT_TESTING_APP_PROJECT_ID }}
           aliases: |
-            scion-workbench-client-testing-app1.vercel.app,
-            scion-workbench-client-testing-app2.vercel.app,
+            workbench-client-testing-app1.scion.vercel.app,
+            workbench-client-testing-app2.scion.vercel.app,
       - name: 'Deploying workbench-getting-started-app to Vercel'
         uses: SchweizerischeBundesbahnen/scion-toolkit/.github/actions/vercel-deploy@master
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -290,7 +290,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_WORKBENCH_GETTING_STARTED_APP_PROJECT_ID }}
-          aliases: scion-workbench-getting-started.vercel.app
+          aliases: workbench-getting-started.scion.vercel.app
   release-workbench:
     name: 'Releasing @scion/workbench'
     if: ${{ needs.workbench-release-guard.outputs.should-release == 'true' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,9 +325,9 @@ This chapter describes the tasks to publish a new release for `@scion/workbench`
    - Creates a release on GitHub (https://github.com/SchweizerischeBundesbahnen/scion-workbench/releases)
    - Deploys following apps to Vercel:
      - https://scion-workbench-getting-started.vercel.app
-     - https://scion-workbench-testing-app.vercel.app
-     - https://scion-workbench-client-testing-app1.vercel.app (contributes microfrontends)
-     - https://scion-workbench-client-testing-app2.vercel.app (contributes microfrontends)
+     - https://workbench-testing-app.scion.vercel.app
+     - https://workbench-client-testing-app1.scion.vercel.app (contributes microfrontends)
+     - https://workbench-client-testing-app2.scion.vercel.app (contributes microfrontends)
 
 </details>
 
@@ -347,9 +347,9 @@ This chapter describes the tasks to publish a new release for `@scion/workbench-
     - Creates a release on GitHub (https://github.com/SchweizerischeBundesbahnen/scion-workbench/releases)
     - Deploys following apps to Vercel:
         - https://scion-workbench-getting-started.vercel.app
-        - https://scion-workbench-testing-app.vercel.app
-        - https://scion-workbench-client-testing-app1.vercel.app (contributes microfrontends)
-        - https://scion-workbench-client-testing-app2.vercel.app (contributes microfrontends)
+        - https://workbench-testing-app.scion.vercel.app
+        - https://workbench-client-testing-app1.scion.vercel.app (contributes microfrontends)
+        - https://workbench-client-testing-app2.scion.vercel.app (contributes microfrontends)
     - Publishes API documentation (TypeDoc) to Vercel:
         - https://scion-workbench-client-api.vercel.app
         - https://scion-workbench-client-api-vX-X-X.vercel.app 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,8 +351,8 @@ This chapter describes the tasks to publish a new release for `@scion/workbench-
         - https://workbench-client-testing-app1.scion.vercel.app (contributes microfrontends)
         - https://workbench-client-testing-app2.scion.vercel.app (contributes microfrontends)
     - Publishes API documentation (TypeDoc) to Vercel:
-        - https://scion-workbench-client-api.vercel.app
-        - https://scion-workbench-client-api-vX-X-X.vercel.app 
+        - https://workbench-client-api.scion.vercel.app
+        - https://workbench-client-api-vX-X-X.scion.vercel.app 
 </details>
 
 [link-github-actions-workflow]: https://github.com/SchweizerischeBundesbahnen/scion-workbench/actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,7 +324,7 @@ This chapter describes the tasks to publish a new release for `@scion/workbench`
    - Publishes `@scion/workbench` package to NPM (https://www.npmjs.com/package/@scion/workbench)
    - Creates a release on GitHub (https://github.com/SchweizerischeBundesbahnen/scion-workbench/releases)
    - Deploys following apps to Vercel:
-     - https://scion-workbench-getting-started.vercel.app
+     - https://workbench-getting-started.scion.vercel.app
      - https://workbench-testing-app.scion.vercel.app
      - https://workbench-client-testing-app1.scion.vercel.app (contributes microfrontends)
      - https://workbench-client-testing-app2.scion.vercel.app (contributes microfrontends)
@@ -346,7 +346,7 @@ This chapter describes the tasks to publish a new release for `@scion/workbench-
     - Publishes `@scion/workbench-client` package to NPM (https://www.npmjs.com/package/@scion/workbench-client)
     - Creates a release on GitHub (https://github.com/SchweizerischeBundesbahnen/scion-workbench/releases)
     - Deploys following apps to Vercel:
-        - https://scion-workbench-getting-started.vercel.app
+        - https://workbench-getting-started.scion.vercel.app
         - https://workbench-testing-app.scion.vercel.app
         - https://workbench-client-testing-app1.scion.vercel.app (contributes microfrontends)
         - https://workbench-client-testing-app2.scion.vercel.app (contributes microfrontends)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ SCION Workbench enables the creation of Angular web applications that require a 
 [link-howto]: /docs/site/howto/how-to.md
 [link-demo-app]: https://schweizerischebundesbahnen.github.io/scion-workbench-demo/#/(view.24:person/64//view.22:person/32//view.5:person/79//view.3:person/15//view.2:person/38//view.1:person/66//activity:person-list)?viewgrid=eyJpZCI6MSwic2FzaDEiOlsidmlld3BhcnQuMSIsInZpZXcuMSIsInZpZXcuMiIsInZpZXcuMSJdLCJzYXNoMiI6eyJpZCI6Miwic2FzaDEiOlsidmlld3BhcnQuMiIsInZpZXcuMyIsInZpZXcuMyJdLCJzYXNoMiI6eyJpZCI6Mywic2FzaDEiOlsidmlld3BhcnQuNCIsInZpZXcuMjQiLCJ2aWV3LjI0Il0sInNhc2gyIjpbInZpZXdwYXJ0LjMiLCJ2aWV3LjIyIiwidmlldy41Iiwidmlldy4yMiJdLCJzcGxpdHRlciI6MC41MTk0Mzg0NDQ5MjQ0MDY2LCJoc3BsaXQiOmZhbHNlfSwic3BsaXR0ZXIiOjAuNTU5NDI0MzI2ODMzNzk3NSwiaHNwbGl0Ijp0cnVlfSwic3BsaXR0ZXIiOjAuMzIyNjI3NzM3MjI2Mjc3MywiaHNwbGl0IjpmYWxzZX0%3D
 [link-playground-app]: https://workbench-testing-app.scion.vercel.app
-[link-getting-started-app]: https://scion-workbench-getting-started.vercel.app
+[link-getting-started-app]: https://workbench-getting-started.scion.vercel.app
 [link-features]: /docs/site/features.md
 [link-announcements]: /docs/site/announcements.md
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ SCION Workbench enables the creation of Angular web applications that require a 
 [link-getting-started]: /docs/site/getting-started.md
 [link-howto]: /docs/site/howto/how-to.md
 [link-demo-app]: https://schweizerischebundesbahnen.github.io/scion-workbench-demo/#/(view.24:person/64//view.22:person/32//view.5:person/79//view.3:person/15//view.2:person/38//view.1:person/66//activity:person-list)?viewgrid=eyJpZCI6MSwic2FzaDEiOlsidmlld3BhcnQuMSIsInZpZXcuMSIsInZpZXcuMiIsInZpZXcuMSJdLCJzYXNoMiI6eyJpZCI6Miwic2FzaDEiOlsidmlld3BhcnQuMiIsInZpZXcuMyIsInZpZXcuMyJdLCJzYXNoMiI6eyJpZCI6Mywic2FzaDEiOlsidmlld3BhcnQuNCIsInZpZXcuMjQiLCJ2aWV3LjI0Il0sInNhc2gyIjpbInZpZXdwYXJ0LjMiLCJ2aWV3LjIyIiwidmlldy41Iiwidmlldy4yMiJdLCJzcGxpdHRlciI6MC41MTk0Mzg0NDQ5MjQ0MDY2LCJoc3BsaXQiOmZhbHNlfSwic3BsaXR0ZXIiOjAuNTU5NDI0MzI2ODMzNzk3NSwiaHNwbGl0Ijp0cnVlfSwic3BsaXR0ZXIiOjAuMzIyNjI3NzM3MjI2Mjc3MywiaHNwbGl0IjpmYWxzZX0%3D
-[link-playground-app]: https://scion-workbench-testing-app.vercel.app
+[link-playground-app]: https://workbench-testing-app.scion.vercel.app
 [link-getting-started-app]: https://scion-workbench-getting-started.vercel.app
 [link-features]: /docs/site/features.md
 [link-announcements]: /docs/site/announcements.md

--- a/apps/workbench-client-testing-app/src/environments/environment.vercel.ts
+++ b/apps/workbench-client-testing-app/src/environments/environment.vercel.ts
@@ -16,11 +16,11 @@ export const environment = {
   apps: {
     app1: {
       symbolicName: 'workbench-client-testing-app1',
-      url: 'http://scion-workbench-client-testing-app1.vercel.app',
+      url: 'https://workbench-client-testing-app1.scion.vercel.app',
     },
     app2: {
       symbolicName: 'workbench-client-testing-app2',
-      url: 'http://scion-workbench-client-testing-app2.vercel.app',
+      url: 'https://workbench-client-testing-app2.scion.vercel.app',
     },
   },
 };

--- a/apps/workbench-testing-app/src/environments/environment.ts
+++ b/apps/workbench-testing-app/src/environments/environment.ts
@@ -31,7 +31,7 @@ const microfrontendPlatformConfig: MicrofrontendPlatformConfig = {
   applications: [
     {symbolicName: 'workbench-client-testing-app1', manifestUrl: 'http://localhost:4201/manifest-app1.json', intentionRegisterApiDisabled: false},
     {symbolicName: 'workbench-client-testing-app2', manifestUrl: 'http://localhost:4202/manifest-app2.json', intentionRegisterApiDisabled: false},
-    {symbolicName: 'devtools', manifestUrl: 'https://scion-microfrontend-platform-devtools-v1-3-0.vercel.app/manifest.json', intentionCheckDisabled: true, scopeCheckDisabled: true},
+    {symbolicName: 'devtools', manifestUrl: 'https://microfrontend-platform-devtools-v1-3-1.scion.vercel.app/manifest.json', intentionCheckDisabled: true, scopeCheckDisabled: true},
   ],
 };
 

--- a/apps/workbench-testing-app/src/environments/environment.vercel.ts
+++ b/apps/workbench-testing-app/src/environments/environment.vercel.ts
@@ -22,7 +22,7 @@ const microfrontendPlatformConfig: MicrofrontendPlatformConfig = {
   applications: [
     {symbolicName: 'workbench-client-testing-app1', manifestUrl: 'https://scion-workbench-client-testing-app1.vercel.app/manifest-app1.json', intentionRegisterApiDisabled: false},
     {symbolicName: 'workbench-client-testing-app2', manifestUrl: 'https://scion-workbench-client-testing-app2.vercel.app/manifest-app2.json', intentionRegisterApiDisabled: false},
-    {symbolicName: 'devtools', manifestUrl: 'https://scion-microfrontend-platform-devtools-v1-3-0.vercel.app/manifest.json', intentionCheckDisabled: true, scopeCheckDisabled: true},
+    {symbolicName: 'devtools', manifestUrl: 'https://microfrontend-platform-devtools-v1-3-1.scion.vercel.app/manifest.json', intentionCheckDisabled: true, scopeCheckDisabled: true},
   ],
 };
 

--- a/apps/workbench-testing-app/src/environments/environment.vercel.ts
+++ b/apps/workbench-testing-app/src/environments/environment.vercel.ts
@@ -20,8 +20,8 @@ const microfrontendPlatformConfig: MicrofrontendPlatformConfig = {
     manifest: workbenchManifest,
   },
   applications: [
-    {symbolicName: 'workbench-client-testing-app1', manifestUrl: 'https://scion-workbench-client-testing-app1.vercel.app/manifest-app1.json', intentionRegisterApiDisabled: false},
-    {symbolicName: 'workbench-client-testing-app2', manifestUrl: 'https://scion-workbench-client-testing-app2.vercel.app/manifest-app2.json', intentionRegisterApiDisabled: false},
+    {symbolicName: 'workbench-client-testing-app1', manifestUrl: 'https://workbench-client-testing-app1.scion.vercel.app/manifest-app1.json', intentionRegisterApiDisabled: false},
+    {symbolicName: 'workbench-client-testing-app2', manifestUrl: 'https://workbench-client-testing-app2.scion.vercel.app/manifest-app2.json', intentionRegisterApiDisabled: false},
     {symbolicName: 'devtools', manifestUrl: 'https://microfrontend-platform-devtools-v1-3-1.scion.vercel.app/manifest.json', intentionCheckDisabled: true, scopeCheckDisabled: true},
   ],
 };

--- a/docs/site/announcements.md
+++ b/docs/site/announcements.md
@@ -46,7 +46,7 @@ On the way to a true workbench layout, we deprecate activities to introduce the 
 
 [link-scion-microfrontend-platform]: https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform/blob/master/README.md 
 [link-scion-workbench-client]: https://www.npmjs.com/package/@scion/workbench-client
-[link-scion-workbench-client-api]: https://scion-workbench-client-api.vercel.app
+[link-scion-workbench-client-api]: https://workbench-client-api.scion.vercel.app
 [link-workbench-config.ts]: https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/projects/scion/workbench/src/lib/workbench-config.ts
 
 [menu-home]: /README.md

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -10,7 +10,7 @@ We will create a simple TODO app to introduce you to the SCION Workbench. This s
 The application lists TODOs on the left side. When the user clicks a TODO, a new view opens displaying the TODO. Different TODOs open a different view. To open a TODO multiple times, the Ctrl key can be pressed. The user can size and arrange views by drag and drop.
 
 ***
-- After you complete this guide, the application will look like this: https://scion-workbench-getting-started.vercel.app.
+- After you complete this guide, the application will look like this: https://workbench-getting-started.scion.vercel.app.
 - The source code of the application can be found <a href="https://github.com/SchweizerischeBundesbahnen/scion-workbench/raw/master/apps/workbench-getting-started-app/src">here</a>.
 ***
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/router": "18.0.2",
         "@scion/components": "18.1.1",
         "@scion/components.internal": "18.0.1",
-        "@scion/microfrontend-platform": "1.3.0",
+        "@scion/microfrontend-platform": "1.3.1",
         "@scion/toolkit": "1.6.0",
         "rxjs": "7.8.1",
         "tslib": "2.6.3",
@@ -4698,9 +4698,9 @@
       }
     },
     "node_modules/@scion/microfrontend-platform": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scion/microfrontend-platform/-/microfrontend-platform-1.3.0.tgz",
-      "integrity": "sha512-UmdTCuLeB4K3TpK3dj46kU0hUZ1eiBUYOWHSLQS1OhizfKdnWQWmLdCjs/+m2vI+DmpgA3naDgzKjlnK7/hNog==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@scion/microfrontend-platform/-/microfrontend-platform-1.3.1.tgz",
+      "integrity": "sha512-/7ZhxgBy24r19iJyQswvo8cQmtGYkm55B9H+L9nbAIstpKmHIoCnmTzzBuvF/IxFbAjgBeH49yBkrXtC/O/IEQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@angular/router": "18.0.2",
     "@scion/components": "18.1.1",
     "@scion/components.internal": "18.0.1",
-    "@scion/microfrontend-platform": "1.3.0",
+    "@scion/microfrontend-platform": "1.3.1",
     "@scion/toolkit": "1.6.0",
     "rxjs": "7.8.1",
     "tslib": "2.6.3",

--- a/projects/scion/workbench-client/src/lib/workbench-client.ts
+++ b/projects/scion/workbench-client/src/lib/workbench-client.ts
@@ -69,31 +69,31 @@ import {StyleSheetInstaller} from './style-sheet-installer';
  * uses iframes to embed microfrontends; thus, any web page can be integrated as a microfrontend. A micro application can communicate with other micro applications safely
  * using the platform's cross-origin messaging API. A micro application has to provide an application manifest which to register in the host application.
  *
- * For more information, see the chapter [Core Concepts](https://scion-microfrontend-platform-developer-guide.vercel.app/#_core_concepts)
+ * For more information, see the chapter [Core Concepts](https://microfrontend-platform-developer-guide.scion.vercel.app/#_core_concepts)
  * of the SCION Microfrontend Platform Developer's Guide.
  *
  * #### Embedding of Microfrontends
  * You can embed microfrontends using the `<sci-router-outlet>` web component. Web content displayed in the web component is controlled via the `OutletRouter`.
  *
- * For more information, see the chapter [Embedding Microfrontends](https://scion-microfrontend-platform-developer-guide.vercel.app/#chapter:embedding-microfrontends)
+ * For more information, see the chapter [Embedding Microfrontends](https://microfrontend-platform-developer-guide.scion.vercel.app/#chapter:embedding-microfrontends)
  * of the SCION Microfrontend Platform Developer's Guide.
  *
  * #### Cross-Application Communication
  * You can interact with other micro applications via messaging or through so-called intents. Intents are a mechanism known from Android development,
  * enabling controlled collaboration across application boundaries.
  *
- * For more information, see the chapters [Cross-Application Communication](https://scion-microfrontend-platform-developer-guide.vercel.app/#chapter:cross-application-communication)
- * and [Intention API](https://scion-microfrontend-platform-developer-guide.vercel.app/#chapter:intention-api) of the SCION Microfrontend Platform Developer's Guide.
+ * For more information, see the chapters [Cross-Application Communication](https://microfrontend-platform-developer-guide.scion.vercel.app/#chapter:cross-application-communication)
+ * and [Intention API](https://microfrontend-platform-developer-guide.scion.vercel.app/#chapter:intention-api) of the SCION Microfrontend Platform Developer's Guide.
  *
  * #### Activation
  * You can provide an activator to connect to the platform when the user loads the host app into his browser, allowing to initialize and install message listeners for interacting
  * with other micro applications. Starting an activator may take some time. In order not to miss any messages, you can instruct the platform host to wait until you signal
  * readiness.
  *
- * For more information, see the chapter [Activator](https://scion-microfrontend-platform-developer-guide.vercel.app/#chapter:activator) of the SCION Microfrontend
+ * For more information, see the chapter [Activator](https://microfrontend-platform-developer-guide.scion.vercel.app/#chapter:activator) of the SCION Microfrontend
  * Platform Developer's Guide.
  *
- * See our [Developer's Guide](https://scion-microfrontend-platform-developer-guide.vercel.app) for the full documentation about the
+ * See our [Developer's Guide](https://microfrontend-platform-developer-guide.scion.vercel.app) for the full documentation about the
  * [SCION Microfrontend Platform](https://github.com/SchweizerischeBundesbahnen/scion-microfrontend-platform).
  */
 export class WorkbenchClient {

--- a/projects/scion/workbench-client/tsconfig.lib.prod.typedoc.json
+++ b/projects/scion/workbench-client/tsconfig.lib.prod.typedoc.json
@@ -19,9 +19,9 @@
     },
     "externalSymbolLinkMappings": {
       "@scion/microfrontend-platform": {
-        "MicrofrontendPlatform": "https://scion-microfrontend-platform-api.vercel.app/classes/MicrofrontendPlatform.html",
-        "MicrofrontendPlatformClient.connect": "https://scion-microfrontend-platform-api.vercel.app/classes/MicrofrontendPlatformClient.html#connect",
-        "PreferredSizeService": "https://scion-microfrontend-platform-api.vercel.app/classes/PreferredSizeService.html"
+        "MicrofrontendPlatform": "https://microfrontend-platform-api.scion.vercel.app/classes/MicrofrontendPlatform.html",
+        "MicrofrontendPlatformClient.connect": "https://microfrontend-platform-api.scion.vercel.app/classes/MicrofrontendPlatformClient.html#connect",
+        "PreferredSizeService": "https://microfrontend-platform-api.scion.vercel.app/classes/PreferredSizeService.html"
       }
     }
   }


### PR DESCRIPTION
We have identified performance degradation for iframes not deployed in the same subdomain, most likely to throttle third-party iframes such as analytics and tracking tools. Performance degradation manifests, for example, when resizing the iframe where iframe content adapts to the iframe size with a slight delay.

Therefore, we now deploy the host and micro applications to the same subdomain but in different second-level subdomains (`*.scion.vercel.app`). The cross-origin policy still applies, i.e., a micro app cannot access other browsing contexts.

- Previous URL: https://scion-workbench-testing-app.vercel.app
- New URL: https://workbench-testing-app.scion.vercel.app

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [x] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #614

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


