### PR TITLE
fix(workbench/part): ensure docked part opens when its handle is activated

### DIFF
--- a/projects/scion/workbench/src/lib/layout/workbench-layout.spec.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.spec.ts
@@ -1978,6 +1978,37 @@ describe('WorkbenchLayout', () => {
     expect(workbenchLayout.grid({partId: 'part.99'}, {orElse: null})).toBeNull();
   });
 
+  /**
+   * The test operates on the following layout:
+   *
+   *           MTreeNode (root)
+   *                |
+   *    +-----------+-----------+
+   *    |                       |
+   * part.left                MTreeNode (child)
+   *                      +-----+-----+
+   *                      |           |
+   *                   part.right  part.bottom
+   */
+  it('should find tree node by criteria', () => {
+    TestBed.overrideProvider(MAIN_AREA_INITIAL_PART_ID, {useValue: 'part.initial'});
+
+    const workbenchLayout = TestBed.inject(ɵWorkbenchLayoutFactory)
+      .addPart('part.left')
+      .addPart('part.right', {align: 'right', relativeTo: 'part.left'})
+      .addPart('part.bottom', {align: 'bottom', relativeTo: 'part.right'});
+
+    const rootTreeNode = workbenchLayout.part({partId: 'part.left'}).parent!;
+    const childTreeNode = workbenchLayout.part({partId: 'part.right'}).parent!;
+
+    // Find by node id.
+    expect(workbenchLayout.treeNode({nodeId: childTreeNode.id})).toBe(childTreeNode);
+    expect(workbenchLayout.treeNode({nodeId: childTreeNode.id})).toBe(workbenchLayout.part({partId: 'part.right'}).parent);
+    expect(workbenchLayout.treeNode({nodeId: childTreeNode.id})).toBe(workbenchLayout.part({partId: 'part.bottom'}).parent);
+    expect(workbenchLayout.treeNode({nodeId: rootTreeNode.id})).toBe(rootTreeNode);
+    expect(workbenchLayout.treeNode({nodeId: rootTreeNode.id})).toBe(childTreeNode.parent);
+  });
+
   it('should return whether a part is contained in the layout', () => {
     TestBed.overrideProvider(MAIN_AREA_INITIAL_PART_ID, {useValue: 'part.initial'});
 
@@ -2335,8 +2366,8 @@ describe('WorkbenchLayout', () => {
     workbenchLayout = workbenchLayout.setTreeNodeSplitRatio(findParentNode('part.left').id, .3);
     expect(findParentNode('part.left').ratio).toEqual(.3);
 
-    // Expect to error if setting the ratio for a node not contained in the layout.
-    expect(() => workbenchLayout.setTreeNodeSplitRatio('does-not-exist', .3)).toThrowError(/NullElementError/);
+    // Expect to error if setting the ratio on a node not contained in the layout.
+    expect(() => workbenchLayout.setTreeNodeSplitRatio('does-not-exist', .3)).toThrowError(/NullTreeNodeError/);
 
     // Expect to error if setting an illegal ratio.
     expect(() => workbenchLayout.setTreeNodeSplitRatio(findParentNode('part.left').id, -.1)).toThrowError(/LayoutModifyError/);

--- a/projects/scion/workbench/src/lib/layout/ɵworkbench-layout.ts
+++ b/projects/scion/workbench/src/lib/layout/ɵworkbench-layout.ts
@@ -602,9 +602,23 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
     return workingCopy;
   }
 
-  /** @inheritDoc */
-  public modify(modifyFn: (layout: ɵWorkbenchLayout) => ɵWorkbenchLayout): ɵWorkbenchLayout {
-    return modifyFn(this.workingCopy());
+  /**
+   * Finds a {@link MTreeNode} based on the specified filter. If not found, by default, throws an error unless setting the `orElseNull` option.
+   *
+   * @param findBy - Defines the search scope.
+   * @param findBy.nodeId - Searches for a node with the specified id.
+   * @param options - Controls the search.
+   * @param options.orElse - Controls to return `null` instead of throwing an error if no node is found.
+   * @return node matching the filter criteria.
+   */
+  public treeNode(findBy: {nodeId: string}): MTreeNode;
+  public treeNode(findBy: {nodeId: string}, options: {orElse: null}): MTreeNode | null;
+  public treeNode(findBy: {nodeId: string}, options?: {orElse: null}): MTreeNode | null {
+    const [node] = this.findTreeElements((element: MTreeNode | MPart): element is MTreeNode => element instanceof MTreeNode && element.id === findBy.nodeId);
+    if (!node && !options) {
+      throw Error(`[NullTreeNodeError] No MTreeNode found with id '${findBy.nodeId}'.`);
+    }
+    return node ?? null;
   }
 
   /**
@@ -619,6 +633,11 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
     const workingCopy = this.workingCopy();
     workingCopy.__setTreeNodeSplitRatio(nodeId, ratio);
     return workingCopy;
+  }
+
+  /** @inheritDoc */
+  public modify(modifyFn: (layout: ɵWorkbenchLayout) => ɵWorkbenchLayout): ɵWorkbenchLayout {
+    return modifyFn(this.workingCopy());
   }
 
   /**
@@ -1185,7 +1204,7 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
     if (ratio < 0 || ratio > 1) {
       throw Error(`[LayoutModifyError] Ratio for node '${nodeId}' must be in the closed interval [0,1], but was '${ratio}'.`);
     }
-    this.findTreeElement<MTreeNode>({id: nodeId}).ratio = ratio;
+    this.treeNode({nodeId}).ratio = ratio;
   }
 
   /**

--- a/projects/scion/workbench/src/lib/part/ɵworkbench-part.model.ts
+++ b/projects/scion/workbench/src/lib/part/ɵworkbench-part.model.ts
@@ -101,7 +101,7 @@ export class ɵWorkbenchPart implements WorkbenchPart {
     const {gridName, grid} = layout.grid({partId: this.id});
     this.gridName.set(gridName);
     this.peripheral.set(layout.isPeripheralPart(this.id));
-    this.active.set(grid.activePartId === this.id);
+    this.active.set(isActive(this.id, layout));
     this.viewIds.set(mPart.views.map(view => view.id));
     this.activeViewId.set(mPart.activeViewId ?? null);
     this.activity.set(layout.activity({partId: this.id}, {orElse: null}));
@@ -297,7 +297,7 @@ export class ɵWorkbenchPart implements WorkbenchPart {
 }
 
 /**
- * Tests if this part is the top-leftmost part.
+ * Computes if this part is the top-leftmost part.
  */
 function isTopLeft(element: MTreeNode | MPart, testee: MPart): boolean {
   if (element instanceof MPart) {
@@ -309,7 +309,7 @@ function isTopLeft(element: MTreeNode | MPart, testee: MPart): boolean {
 }
 
 /**
- * Tests if this part is the top-rightmost part.
+ * Computes if this part is the top-rightmost part.
  */
 function isTopRight(element: MTreeNode | MPart, testee: MPart): boolean {
   if (element instanceof MPart) {
@@ -323,6 +323,25 @@ function isTopRight(element: MTreeNode | MPart, testee: MPart): boolean {
     return element.direction === 'column' ? isTopRight(element.child1, testee) : isTopRight(element.child2, testee);
   }
   return isTopRight(child1Visible ? element.child1 : element.child2, testee);
+}
+
+/**
+ * Computes if the given part is active.
+ *
+ * A part is considered active if it is the currently active part in its grid.
+ * Additionally, if the part is associated with an activity, the activity must also be active.
+ */
+function isActive(partId: PartId, layout: ɵWorkbenchLayout): boolean {
+  const {grid} = layout.grid({partId: partId});
+  if (grid.activePartId !== partId) {
+    return false;
+  }
+
+  const activity = layout.activity({partId: partId}, {orElse: null});
+  if (activity && layout.activityStack({activityId: activity.id}).activeActivityId !== activity.id) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/projects/scion/workbench/src/lib/testing/jasmine/matcher/to-equal-workbench-layout.matcher.ts
+++ b/projects/scion/workbench/src/lib/testing/jasmine/matcher/to-equal-workbench-layout.matcher.ts
@@ -358,8 +358,9 @@ function assertMTreeNodeDOM(expectedTreeNode: MTreeNode, actualElement: Element,
     throw Error(`[DOMAssertError] Expected element 'wb-grid-element' to have attribute 'data-nodeid', but is missing. [MTreeNode=${JSON.stringify(expectedTreeNode)}]`);
   }
 
-  const child1Visible = WorkbenchLayouts.isGridElementVisible(expectedTreeNode.child1);
-  const child2Visible = WorkbenchLayouts.isGridElementVisible(expectedTreeNode.child2);
+  const actualTreeNode: MTreeNode = TestBed.inject(WorkbenchLayoutService).layout().treeNode({nodeId});
+  const child1Visible = WorkbenchLayouts.isGridElementVisible(actualTreeNode.child1);
+  const child2Visible = WorkbenchLayouts.isGridElementVisible(actualTreeNode.child2);
 
   // Assert sashbox.
   if (child1Visible && child2Visible) {


### PR DESCRIPTION
Previously, activating a part handle did not open the associated activity if the part was already the active part within the activity's grid.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
