### PR TITLE
fix(workbench): preserve main area in perspectives without a main area

### DIFF
--- a/projects/scion/e2e-testing/src/workbench-accessor.ts
+++ b/projects/scion/e2e-testing/src/workbench-accessor.ts
@@ -9,7 +9,8 @@
  */
 
 import {Page} from '@playwright/test';
-import {PartId, ViewId, WorkbenchPart, WorkbenchService, WorkbenchView} from '@scion/workbench';
+import {PartId, ViewId, WorkbenchService} from '@scion/workbench';
+import {RequireOne} from './helper/utility-types';
 
 /**
  * Enables programmatic interaction with the Workbench API.
@@ -26,17 +27,104 @@ export class WorkbenchAccessor {
     }, viewIds);
   }
 
-  public views(): Promise<Array<Pick<WorkbenchView, 'id' | 'alternativeId'> & {partId: PartId}>> {
-    return this._page.evaluate(() => {
+  /**
+   * Finds views based on given criteria.
+   */
+  public views(findBy?: {id?: ViewId; alternativeId?: string}): Promise<E2EWorkbenchView[]> {
+    return this._page.evaluate(findBy => {
       const workbenchService = (window as unknown as Record<string, unknown>).__workbenchService as WorkbenchService;
-      return workbenchService.views().map(view => ({id: view.id, alternativeId: view.alternativeId, partId: view.part().id}));
-    });
+      return workbenchService.views()
+        .filter(view => {
+          if (findBy?.id && findBy.id !== view.id) {
+            return false;
+          }
+          if (findBy?.alternativeId && findBy.alternativeId !== view.alternativeId) {
+            return false;
+          }
+          return true;
+        })
+        .map(view => ({
+          id: view.id,
+          alternativeId: view.alternativeId,
+          partId: view.part().id,
+          navigation: {
+            path: view.navigation()?.path.join('/'),
+            hint: view.navigation()?.hint,
+          },
+        }));
+    }, findBy);
   }
 
-  public parts(): Promise<Array<Pick<WorkbenchPart, 'id' | 'alternativeId'>>> {
-    return this._page.evaluate(() => {
+  /**
+   * Finds parts based on given criteria.
+   */
+  public parts(findBy?: {id?: PartId; alternativeId?: string}): Promise<E2EWorkbenchPart[]> {
+    return this._page.evaluate(findBy => {
       const workbenchService = (window as unknown as Record<string, unknown>).__workbenchService as WorkbenchService;
-      return workbenchService.parts().map(part => ({id: part.id, alternativeId: part.alternativeId}));
-    });
+      return workbenchService.parts()
+        .filter(part => {
+          if (findBy?.id && findBy.id !== part.id) {
+            return false;
+          }
+          if (findBy?.alternativeId && findBy.alternativeId !== part.alternativeId) {
+            return false;
+          }
+          return true;
+        })
+        .map(part => ({
+          id: part.id,
+          alternativeId: part.alternativeId,
+          navigation: {
+            path: part.navigation()?.path.join('/'),
+            hint: part.navigation()?.hint,
+          },
+        }));
+    }, findBy);
   }
+
+  /**
+   * Finds a view based on given criteria, throwing an error if none or multiple views are found.
+   */
+  public async view(findBy: RequireOne<{id: ViewId; alternativeId: string}>): Promise<E2EWorkbenchView> {
+    const views = await this.views(findBy);
+    if (!views.length) {
+      throw Error(`[PageObjectError] No view found: ${JSON.stringify(findBy)}`);
+    }
+    if (views.length > 1) {
+      throw Error(`[PageObjectError] Multiple views found: ${JSON.stringify(findBy)}`);
+    }
+    return views[0]!;
+  }
+
+  /**
+   * Finds a part based on given criteria, throwing an error if none or multiple parts are found.
+   */
+  public async part(findBy: RequireOne<{id: PartId; alternativeId: string}>): Promise<E2EWorkbenchPart> {
+    const parts = await this.parts(findBy);
+    if (!parts.length) {
+      throw Error(`[PageObjectError] No part found: ${JSON.stringify(findBy)}`);
+    }
+    if (parts.length > 1) {
+      throw Error(`[PageObjectError] Multiple parts found: ${JSON.stringify(findBy)}`);
+    }
+    return parts[0]!;
+  }
+}
+
+export interface E2EWorkbenchView {
+  id: ViewId;
+  alternativeId: string | undefined;
+  partId: PartId;
+  navigation: E2EWorkbenchViewNavigation;
+}
+
+export interface E2EWorkbenchPart {
+  id: PartId;
+  alternativeId: string | undefined;
+  navigation: E2EWorkbenchViewNavigation;
+}
+
+export interface E2EWorkbenchViewNavigation {
+  path?: string;
+  hint?: string;
 }

--- a/projects/scion/e2e-testing/src/workbench/browser-history.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/browser-history.e2e-spec.ts
@@ -33,8 +33,8 @@ test.describe('Browser Session History', () => {
     await appPO.navigateTo({microfrontendSupport: false});
 
     // Create two perspectives (no activation).
-    await workbenchNavigator.createPerspective('testee-1', factory => factory.addPart(MAIN_AREA), {active: false});
-    await workbenchNavigator.createPerspective('testee-2', factory => factory.addPart(MAIN_AREA), {active: false});
+    await workbenchNavigator.createPerspective('testee-1', factory => factory.addPart(MAIN_AREA), {activate: false});
+    await workbenchNavigator.createPerspective('testee-2', factory => factory.addPart(MAIN_AREA), {activate: false});
 
     await test.step('Switching to perspective 1 (initial perspective activation)', async () => {
       // Capture browser session history count.

--- a/projects/scion/e2e-testing/src/workbench/main-area.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/main-area.e2e-spec.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2018-2025 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {test} from '../fixtures';
+import {MAIN_AREA} from '../workbench.model';
+import {expect} from '@playwright/test';
+import {MPart, MTreeNode} from '../matcher/to-equal-workbench-layout.matcher';
+
+test.describe('Main Area', () => {
+
+  test('should share main area between perspectives', async ({appPO, workbenchNavigator}) => {
+    await appPO.navigateTo({microfrontendSupport: false, mainAreaInitialPartId: 'part.main-area-top'});
+
+    // Create perspective 1.
+    await workbenchNavigator.createPerspective('perspective.1', factory => factory
+      .addPart(MAIN_AREA)
+      .addPart('part.left', {align: 'left', ratio: .25})
+      .navigatePart('part.left', ['path/to/part/1']), {activate: false},
+    );
+
+    // Create perspective 2.
+    await workbenchNavigator.createPerspective('perspective.2', factory => factory
+      .addPart(MAIN_AREA)
+      .addPart('part.right', {align: 'right', ratio: .25})
+      .navigatePart('part.right', ['path/to/part/2']), {activate: false},
+    );
+
+    // Create perspective 3 (no main area).
+    await workbenchNavigator.createPerspective('perspective.3', factory => factory
+      .addPart('part.main')
+      .navigatePart('part.main', ['path/to/part']), {activate: false},
+    );
+
+    // Add views to the main area.
+    await workbenchNavigator.modifyLayout(layout => layout
+      .addPart('part.main-area-bottom', {relativeTo: 'part.main-area-top', align: 'bottom'})
+      .addView('view.1', {partId: 'part.main-area-top'})
+      .addView('view.2', {partId: 'part.main-area-bottom'})
+      .addView('view.3', {partId: 'part.main-area-bottom'})
+      .navigateView('view.1', ['path/to/view/1'])
+      .navigateView('view.2', ['path/to/view/2'])
+      .navigateView('view.3', ['path/to/view/3'])
+      .activateView('view.1')
+      .activateView('view.2'),
+    );
+
+    await appPO.switchPerspective('perspective.1');
+    await expect(appPO.workbenchRoot).toEqualWorkbenchLayout({
+      grids: {
+        mainArea: {
+          root: new MTreeNode({
+            direction: 'column',
+            ratio: .5,
+            child1: new MPart({
+              id: 'part.main-area-top',
+              views: [{id: 'view.1'}],
+            }),
+            child2: new MPart({
+              id: 'part.main-area-bottom',
+              views: [{id: 'view.2'}, {id: 'view.3'}],
+            }),
+          }),
+        },
+        main: {
+          root: new MTreeNode({
+            direction: 'row',
+            ratio: .25,
+            child1: new MPart({
+              id: 'part.left',
+            }),
+            child2: new MPart({
+              id: MAIN_AREA,
+            }),
+          }),
+        },
+      },
+    });
+    await expect.poll(() => appPO.workbench.view({id: 'view.1'}).then(view => view.navigation.path)).toEqual('path/to/view/1');
+    await expect.poll(() => appPO.workbench.view({id: 'view.2'}).then(view => view.navigation.path)).toEqual('path/to/view/2');
+    await expect.poll(() => appPO.workbench.view({id: 'view.3'}).then(view => view.navigation.path)).toEqual('path/to/view/3');
+
+    // Switch to perspective 2.
+    await appPO.switchPerspective('perspective.2');
+    await expect(appPO.workbenchRoot).toEqualWorkbenchLayout({
+      grids: {
+        mainArea: {
+          root: new MTreeNode({
+            direction: 'column',
+            ratio: .5,
+            child1: new MPart({
+              id: 'part.main-area-top',
+              views: [{id: 'view.1'}],
+            }),
+            child2: new MPart({
+              id: 'part.main-area-bottom',
+              views: [{id: 'view.2'}, {id: 'view.3'}],
+            }),
+          }),
+        },
+        main: {
+          root: new MTreeNode({
+            direction: 'row',
+            ratio: .75,
+            child1: new MPart({
+              id: MAIN_AREA,
+            }),
+            child2: new MPart({
+              id: 'part.right',
+            }),
+          }),
+        },
+      },
+    });
+    await expect.poll(() => appPO.workbench.view({id: 'view.1'}).then(view => view.navigation.path)).toEqual('path/to/view/1');
+    await expect.poll(() => appPO.workbench.view({id: 'view.2'}).then(view => view.navigation.path)).toEqual('path/to/view/2');
+    await expect.poll(() => appPO.workbench.view({id: 'view.3'}).then(view => view.navigation.path)).toEqual('path/to/view/3');
+
+    // Switch to perspective 3 (no main area).
+    await appPO.switchPerspective('perspective.3');
+    await expect(appPO.workbenchRoot).toEqualWorkbenchLayout({
+      grids: {
+        main: {
+          root: new MPart({
+            id: 'part.main',
+          }),
+        },
+      },
+    });
+    await expect.poll(() => appPO.workbench.view({id: 'view.1'}).then(view => view.navigation.path)).toEqual('path/to/view/1');
+    await expect.poll(() => appPO.workbench.view({id: 'view.2'}).then(view => view.navigation.path)).toEqual('path/to/view/2');
+    await expect.poll(() => appPO.workbench.view({id: 'view.3'}).then(view => view.navigation.path)).toEqual('path/to/view/3');
+
+    // Switch to perspective 1.
+    await appPO.switchPerspective('perspective.1');
+    await expect(appPO.workbenchRoot).toEqualWorkbenchLayout({
+      grids: {
+        mainArea: {
+          root: new MTreeNode({
+            direction: 'column',
+            ratio: .5,
+            child1: new MPart({
+              id: 'part.main-area-top',
+              views: [{id: 'view.1'}],
+            }),
+            child2: new MPart({
+              views: [{id: 'view.2'}, {id: 'view.3'}],
+            }),
+          }),
+        },
+        main: {
+          root: new MTreeNode({
+            direction: 'row',
+            ratio: .25,
+            child1: new MPart({
+              id: 'part.left',
+            }),
+            child2: new MPart({
+              id: MAIN_AREA,
+            }),
+          }),
+        },
+      },
+    });
+    await expect.poll(() => appPO.workbench.view({id: 'view.1'}).then(view => view.navigation.path)).toEqual('path/to/view/1');
+    await expect.poll(() => appPO.workbench.view({id: 'view.2'}).then(view => view.navigation.path)).toEqual('path/to/view/2');
+    await expect.poll(() => appPO.workbench.view({id: 'view.3'}).then(view => view.navigation.path)).toEqual('path/to/view/3');
+  });
+});

--- a/projects/scion/e2e-testing/src/workbench/navigational-css-class.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/navigational-css-class.e2e-spec.ts
@@ -257,7 +257,7 @@ test.describe('Navigational CSS Classes', () => {
 
       // Move view to new window.
       const newAppPO = await appPO.view({cssClass: 'testee-navigation'}).tab.moveToNewWindow();
-      const newView = (await newAppPO.workbench.views()).find(view => view.alternativeId === 'testee')!;
+      const newView = await newAppPO.workbench.view({alternativeId: 'testee'});
       const newViewPage = new ViewPagePO(newAppPO, {viewId: newView.id});
 
       // Expect CSS classes of the navigation to be retained
@@ -285,11 +285,11 @@ test.describe('Navigational CSS Classes', () => {
 
       // Move view 1 to new window.
       const newAppPO = await appPO.view({cssClass: 'testee-navigation-1'}).tab.moveToNewWindow();
-      const newView1 = (await newAppPO.workbench.views()).find(view => view.alternativeId === 'testee-1')!;
+      const newView1 = await newAppPO.workbench.view({alternativeId: 'testee-1'});
 
       // Move view 2 to the window.
       await appPO.view({cssClass: 'testee-navigation-2'}).tab.moveTo(newView1.partId, {workbenchId: await newAppPO.getWorkbenchId()});
-      const newView2 = (await newAppPO.workbench.views()).find(view => view.alternativeId === 'testee-2')!;
+      const newView2 = await newAppPO.workbench.view({alternativeId: 'testee-2'});
       const newViewPage2 = new ViewPagePO(newAppPO, {viewId: newView2.id});
 
       // Expect CSS classes of the navigation to be retained.

--- a/projects/scion/e2e-testing/src/workbench/workbench-layout-migration.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench/workbench-layout-migration.e2e-spec.ts
@@ -68,16 +68,14 @@ test.describe('Workbench Layout Migration', () => {
       perspectives: ['testee'],
     });
 
-    const parts = await appPO.workbench.parts();
-    const _33b22f60Part = parts.find(part => part.alternativeId === '33b22f60-bf34-4704-885d-7de0d707430f') ?? throwError(`Part not found with alternativeId '33b22f60-bf34-4704-885d-7de0d707430f'`);
-    const _9bc4c09fPart = parts.find(part => part.alternativeId === '9bc4c09f-67a7-4c69-a28b-532781a1c98f') ?? throwError(`Part not found with alternativeId '9bc4c09f-67a7-4c69-a28b-532781a1c98f'`);
-    const _a25eb4cfPart = parts.find(part => part.alternativeId === 'a25eb4cf-9da7-43e7-8db2-302fd38e59a1') ?? throwError(`Part not found with alternativeId 'a25eb4cf-9da7-43e7-8db2-302fd38e59a1'`);
-    const _2b534d97Part = parts.find(part => part.alternativeId === '2b534d97-ed7d-43b3-bb2c-0e59d9766e86') ?? throwError(`Part not found with alternativeId '2b534d97-ed7d-43b3-bb2c-0e59d9766e86'`);
+    const _33b22f60Part = await appPO.workbench.part({alternativeId: '33b22f60-bf34-4704-885d-7de0d707430f'});
+    const _9bc4c09fPart = await appPO.workbench.part({alternativeId: '9bc4c09f-67a7-4c69-a28b-532781a1c98f'});
+    const _a25eb4cfPart = await appPO.workbench.part({alternativeId: 'a25eb4cf-9da7-43e7-8db2-302fd38e59a1'});
+    const _2b534d97Part = await appPO.workbench.part({alternativeId: '2b534d97-ed7d-43b3-bb2c-0e59d9766e86'});
 
-    const views = await appPO.workbench.views();
-    const testRouterView = views.find(view => view.alternativeId === 'test-router') ?? throwError(`View not found with alternativeId 'test-router'`);
-    const testView = views.find(view => view.alternativeId === 'test-view') ?? throwError(`View not found with alternativeId 'test-view'`);
-    const view3 = views.find(view => view.partId === _33b22f60Part.id) ?? throwError(`Migrated 'view.3' not found`);
+    const testRouterView = await appPO.workbench.view({alternativeId: 'test-router'});
+    const testView = await appPO.workbench.view({alternativeId: 'test-view'});
+    const view3 = (await appPO.workbench.views()).find(view => view.partId === _33b22f60Part.id) ?? throwError(`Migrated 'view.3' not found`);
 
     await expect(appPO.workbenchRoot).toEqualWorkbenchLayout({
       grids: {
@@ -211,11 +209,10 @@ test.describe('Workbench Layout Migration', () => {
       perspectives: ['testee'],
     });
 
-    const parts = await appPO.workbench.parts();
-    const leftPart = parts.find(part => part.alternativeId === 'left') ?? throwError(`Part not found with alternativeId 'left'`);
-    const rightPart = parts.find(part => part.alternativeId === 'right') ?? throwError(`Part not found with alternativeId 'right'`);
-    const _6f09e6e2Part = parts.find(part => part.alternativeId === '6f09e6e2-b63a-4f0d-9ae1-06624fdb37c7') ?? throwError(`Part not found with alternativeId '6f09e6e2-b63a-4f0d-9ae1-06624fdb37c7'`);
-    const _1d94dcb6Part = parts.find(part => part.alternativeId === '1d94dcb6-76b6-47eb-b300-39448993d36b') ?? throwError(`Part not found with alternativeId '1d94dcb6-76b6-47eb-b300-39448993d36b'`);
+    const leftPart = await appPO.workbench.part({alternativeId: 'left'});
+    const rightPart = await appPO.workbench.part({alternativeId: 'right'});
+    const _6f09e6e2Part = await appPO.workbench.part({alternativeId: '6f09e6e2-b63a-4f0d-9ae1-06624fdb37c7'});
+    const _1d94dcb6Part = await appPO.workbench.part({alternativeId: '1d94dcb6-76b6-47eb-b300-39448993d36b'});
 
     const views = await appPO.workbench.views();
     const view2 = views.find(view => view.partId === leftPart.id) ?? throwError(`Migrated 'view.2' not found`);

--- a/projects/scion/e2e-testing/src/workbench/workbench-navigator.ts
+++ b/projects/scion/e2e-testing/src/workbench/workbench-navigator.ts
@@ -114,7 +114,7 @@ export class WorkbenchNavigator {
     const layoutPage = await this.openInNewTab(LayoutPagePO);
     await layoutPage.createPerspective(id, {layout: layoutFn});
     await layoutPage.view.tab.close();
-    if (options?.active ?? true) {
+    if (options?.activate ?? true) {
       await this._appPO.switchPerspective(id);
     }
     return id;
@@ -139,5 +139,5 @@ export interface PerspectiveCreateOptions {
   /**
    * Controls if to activate the perspective.
    */
-  active?: boolean;
+  activate?: boolean;
 }

--- a/projects/scion/workbench/src/lib/desktop/desktop.spec.ts
+++ b/projects/scion/workbench/src/lib/desktop/desktop.spec.ts
@@ -10,7 +10,7 @@
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WorkbenchRouter} from '../routing/workbench-router.service';
-import {styleFixture, waitUntilWorkbenchStarted, waitUntilStable} from '../testing/testing.util';
+import {styleFixture, waitUntilStable, waitUntilWorkbenchStarted} from '../testing/testing.util';
 import {withComponentContent} from '../testing/test.component';
 import {WorkbenchComponent} from '../workbench.component';
 import {expect} from '../testing/jasmine/matcher/custom-matchers.definition';

--- a/projects/scion/workbench/src/lib/layout/workbench-grid.model.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-grid.model.ts
@@ -139,8 +139,10 @@ export interface WorkbenchGrids<T = ɵMPartGrid> {
   main: T;
   /**
    * Reference to the main area grid, a sub-grid embedded by the main area part contained in the main grid.
+   *
+   * The main area grid is always present even if the layout has no main area part, as it is shared between perspectives.
    */
-  mainArea?: T;
+  mainArea: T;
 
   /**
    * Grids associated with activities.

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.spec.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.spec.ts
@@ -224,7 +224,11 @@ describe('WorkbenchLayout', () => {
       },
     });
 
-    expect((workbenchLayout as ɵWorkbenchLayout).grids.mainArea).toBeUndefined();
+    // Expect main area part not to be present.
+    expect((workbenchLayout as ɵWorkbenchLayout).hasPart(MAIN_AREA)).toBeFalse();
+
+    // Expect the main area grid to be present as shared between layouts.
+    expect((workbenchLayout as ɵWorkbenchLayout).grids.mainArea).toBeDefined();
   });
 
   /**
@@ -723,7 +727,7 @@ describe('WorkbenchLayout', () => {
     const workbenchLayout = TestBed.inject(ɵWorkbenchLayoutFactory).create({grids: serializedLayout.grids});
 
     // verify the main area root node.
-    const rootNode = workbenchLayout.grids.mainArea!.root as _MTreeNode;
+    const rootNode = workbenchLayout.grids.mainArea.root as _MTreeNode;
     expect(rootNode).toBeInstanceOf(_MTreeNode);
     expect(rootNode.parent).toBeUndefined();
 
@@ -1270,14 +1274,14 @@ describe('WorkbenchLayout', () => {
       .activateView('view.1')
       .activateView('view.3');
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.left');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.left');
     expect(workbenchLayout.part({partId: 'part.left'}).activeViewId).toEqual('view.1');
     expect(workbenchLayout.part({partId: 'part.right'}).activeViewId).toEqual('view.3');
 
     // Move view.1 to part right
     workbenchLayout = workbenchLayout.moveView('view.1', 'part.right', {activatePart: true, activateView: true});
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.right');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.right');
     expect(workbenchLayout.part({partId: 'part.left'}).activeViewId).toEqual('view.2');
     expect(workbenchLayout.part({partId: 'part.right'}).activeViewId).toEqual('view.1');
   });
@@ -1296,14 +1300,14 @@ describe('WorkbenchLayout', () => {
       .activateView('view.1')
       .activateView('view.3');
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.left');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.left');
     expect(workbenchLayout.part({partId: 'part.left'}).activeViewId).toEqual('view.1');
     expect(workbenchLayout.part({partId: 'part.right'}).activeViewId).toEqual('view.3');
 
     // Move view.1 to part right
     workbenchLayout = workbenchLayout.moveView('view.1', 'part.right');
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.left');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.left');
     expect(workbenchLayout.part({partId: 'part.left'}).activeViewId).toEqual('view.2');
     expect(workbenchLayout.part({partId: 'part.right'}).activeViewId).toEqual('view.3');
   });
@@ -1322,14 +1326,14 @@ describe('WorkbenchLayout', () => {
       .activateView('view.1')
       .activateView('view.3');
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.right');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.right');
     expect(workbenchLayout.part({partId: 'part.left'}).activeViewId).toEqual('view.1');
     expect(workbenchLayout.part({partId: 'part.right'}).activeViewId).toEqual('view.3');
 
     // Move view.1 to part right
     workbenchLayout = workbenchLayout.moveView('view.2', 'part.left', {position: 0, activatePart: true, activateView: true});
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.left');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.left');
     expect(workbenchLayout.part({partId: 'part.left'}).activeViewId).toEqual('view.2');
     expect(workbenchLayout.part({partId: 'part.right'}).activeViewId).toEqual('view.3');
   });
@@ -1348,14 +1352,14 @@ describe('WorkbenchLayout', () => {
       .activateView('view.1')
       .activateView('view.3');
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.right');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.right');
     expect(workbenchLayout.part({partId: 'part.left'}).activeViewId).toEqual('view.1');
     expect(workbenchLayout.part({partId: 'part.right'}).activeViewId).toEqual('view.3');
 
     // Move view.1 to part right
     workbenchLayout = workbenchLayout.moveView('view.2', 'part.left', {position: 0});
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.right');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.right');
     expect(workbenchLayout.part({partId: 'part.left'}).activeViewId).toEqual('view.1');
     expect(workbenchLayout.part({partId: 'part.right'}).activeViewId).toEqual('view.3');
   });
@@ -1477,19 +1481,19 @@ describe('WorkbenchLayout', () => {
       .withArgs('part.D').and.returnValue(2)
       .withArgs('part.E').and.returnValue(5);
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.E');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.E');
 
     workbenchLayout = workbenchLayout.removePart('part.E');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.C');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.C');
 
     workbenchLayout = workbenchLayout.removePart('part.C');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     workbenchLayout = workbenchLayout.removePart('part.A');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.D');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.D');
 
     workbenchLayout = workbenchLayout.removePart('part.D');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
   });
 
   /**
@@ -1511,23 +1515,23 @@ describe('WorkbenchLayout', () => {
 
     // make part 'B' the active part
     workbenchLayout = workbenchLayout.activatePart('part.B');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
 
     // add view to the part 'A'
     workbenchLayout = workbenchLayout.addView('view.1', {partId: 'part.A'});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
 
     // add view to the part 'A'
     workbenchLayout = workbenchLayout.addView('view.2', {partId: 'part.A', activatePart: false});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
 
     // add view to the part 'A'
     workbenchLayout = workbenchLayout.addView('view.3', {partId: 'part.A', activatePart: true});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // add view to the part 'C'
     workbenchLayout = workbenchLayout.addView('view.4', {partId: 'part.C'});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
   });
 
   /**
@@ -1553,23 +1557,23 @@ describe('WorkbenchLayout', () => {
 
     // make part 'B' the active part
     workbenchLayout = workbenchLayout.activatePart('part.B');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
 
     // activate view.1
     workbenchLayout = workbenchLayout.activateView('view.1');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
 
     // activate view.2
     workbenchLayout = workbenchLayout.activateView('view.2', {activatePart: true});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // activate view.3
     workbenchLayout = workbenchLayout.activateView('view.3', {activatePart: false});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // activate view.4
     workbenchLayout = workbenchLayout.activateView('view.4');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
   });
 
   /**
@@ -1583,19 +1587,19 @@ describe('WorkbenchLayout', () => {
     TestBed.overrideProvider(MAIN_AREA_INITIAL_PART_ID, {useValue: 'part.A'});
 
     let workbenchLayout = TestBed.inject(ɵWorkbenchLayoutFactory).addPart(MAIN_AREA);
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // add part to the right of part 'A'
     workbenchLayout = workbenchLayout.addPart('part.B', {relativeTo: 'part.A', align: 'right'});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // add part to the right of part 'B'
     workbenchLayout = workbenchLayout.addPart('part.C', {relativeTo: 'part.B', align: 'right'}, {activate: false});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // add part to the right of part 'C'
     workbenchLayout = workbenchLayout.addPart('part.D', {relativeTo: 'part.C', align: 'right'}, {activate: true});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.D');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.D');
   });
 
   /**
@@ -1622,15 +1626,15 @@ describe('WorkbenchLayout', () => {
       .addView('view.6', {partId: 'part.C'})
       .activatePart('part.B');
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
 
     // remove view from the part 'A'
     workbenchLayout = workbenchLayout.removeView('view.1');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
 
     // remove view from the part 'C'
     workbenchLayout = workbenchLayout.removeView('view.5');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
   });
 
   /**
@@ -1656,19 +1660,19 @@ describe('WorkbenchLayout', () => {
       .addView('view.5', {partId: 'part.C'})
       .addView('view.6', {partId: 'part.C'});
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // activate view of the part 'A'
     workbenchLayout = workbenchLayout.activateView('view.1', {activatePart: true});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // activate view of the part 'C'
     workbenchLayout = workbenchLayout.activateView('view.5', {activatePart: false});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // activate view of the part 'B'
     workbenchLayout = workbenchLayout.activateView('view.3');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
   });
 
   /**
@@ -1694,19 +1698,19 @@ describe('WorkbenchLayout', () => {
       .addView('view.5', {partId: 'part.C'})
       .addView('view.6', {partId: 'part.C'});
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // move view from part 'A' to part 'C'
     workbenchLayout = workbenchLayout.moveView('view.1', 'part.C', {activateView: true});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.A');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.A');
 
     // move view from part 'C' to part 'B'
     workbenchLayout = workbenchLayout.moveView('view.1', 'part.B', {activateView: true, activatePart: true});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
 
     // move view from part 'C' to part 'A'
     workbenchLayout = workbenchLayout.moveView('view.1', 'part.A', {activateView: true, activatePart: false});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.B');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.B');
   });
 
   it('should remove view', () => {
@@ -1926,7 +1930,7 @@ describe('WorkbenchLayout', () => {
 
     // Find by grid.
     expect(workbenchLayout.grid({grid: workbenchLayout.grids.main})).toEqual({gridName: 'main', grid: workbenchLayout.grids.main});
-    expect(workbenchLayout.grid({grid: workbenchLayout.grids.mainArea!})).toEqual({gridName: 'mainArea', grid: workbenchLayout.grids.mainArea});
+    expect(workbenchLayout.grid({grid: workbenchLayout.grids.mainArea})).toEqual({gridName: 'mainArea', grid: workbenchLayout.grids.mainArea});
     expect(workbenchLayout.grid({grid: workbenchLayout.grids['activity.1']!})).toEqual({gridName: 'activity.1', grid: workbenchLayout.grids['activity.1']});
     expect(workbenchLayout.grid({grid: workbenchLayout.grids['activity.2']!})).toEqual({gridName: 'activity.2', grid: workbenchLayout.grids['activity.2']});
 
@@ -2189,27 +2193,27 @@ describe('WorkbenchLayout', () => {
       .addView('view.2', {partId: 'part.part'})
       .addView('view.3', {partId: 'part.part'});
 
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
     expect(workbenchLayout.part({partId: 'part.part'}).activeViewId).toBeUndefined();
 
     // Activate adjacent view
     workbenchLayout = workbenchLayout.activateAdjacentView('view.2');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
     expect(workbenchLayout.part({partId: 'part.part'}).activeViewId).toEqual('view.1');
 
     // Activate adjacent view
     workbenchLayout = workbenchLayout.activateAdjacentView('view.3');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
     expect(workbenchLayout.part({partId: 'part.part'}).activeViewId).toEqual('view.2');
 
     // Activate adjacent view
     workbenchLayout = workbenchLayout.activateAdjacentView('view.1');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
     expect(workbenchLayout.part({partId: 'part.part'}).activeViewId).toEqual('view.2');
 
     // Activate adjacent view
     workbenchLayout = workbenchLayout.activateAdjacentView('view.2', {activatePart: true});
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.part');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.part');
     expect(workbenchLayout.part({partId: 'part.part'}).activeViewId).toEqual('view.1');
   });
 
@@ -2224,27 +2228,27 @@ describe('WorkbenchLayout', () => {
       .addPart('part.outerRight', {relativeTo: MAIN_AREA, align: 'right'});
 
     expect(workbenchLayout.activePart({grid: 'main'}).id).toEqual(MAIN_AREA);
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
 
     // Activate part 'outerLeft'
     workbenchLayout = workbenchLayout.activatePart('part.outerLeft');
     expect(workbenchLayout.activePart({grid: 'main'}).id).toEqual('part.outerLeft');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
 
     // Activate part 'outerRight'
     workbenchLayout = workbenchLayout.activatePart('part.outerRight');
     expect(workbenchLayout.activePart({grid: 'main'}).id).toEqual('part.outerRight');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
 
     // Activate part 'innerLeft'
     workbenchLayout = workbenchLayout.activatePart('part.innerLeft');
     expect(workbenchLayout.activePart({grid: 'main'}).id).toEqual('part.outerRight');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.innerLeft');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.innerLeft');
 
     // Activate part 'innerRight'
     workbenchLayout = workbenchLayout.activatePart('part.innerRight');
     expect(workbenchLayout.activePart({grid: 'main'}).id).toEqual('part.outerRight');
-    expect(workbenchLayout.activePart({grid: 'mainArea'})!.id).toEqual('part.innerRight');
+    expect(workbenchLayout.activePart({grid: 'mainArea'}).id).toEqual('part.innerRight');
   });
 
   it('should allow renaming a view', () => {
@@ -2427,7 +2431,7 @@ describe('WorkbenchLayout', () => {
 
     // Capture model objects. The ids should not change when serializing and deserializing the layout.
     const workbenchLayoutRoot = TestBed.inject(ɵWorkbenchService).layout().grids.main.root;
-    const mainAreaLayoutRoot = TestBed.inject(ɵWorkbenchService).layout().grids.mainArea!.root;
+    const mainAreaLayoutRoot = TestBed.inject(ɵWorkbenchService).layout().grids.mainArea.root;
     const activityPart = TestBed.inject(ɵWorkbenchService).layout().part({partId: 'part.activity'});
     const view100 = TestBed.inject(ɵWorkbenchService).layout().view({viewId: 'view.100'});
     const view101 = TestBed.inject(ɵWorkbenchService).layout().view({viewId: 'view.101'});
@@ -2843,35 +2847,35 @@ describe('WorkbenchLayout', () => {
 
     // Assert active parts after layout creation.
     expect(layout.activePart({grid: 'main'}).id).toEqual('part.main-area');
-    expect(layout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(layout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
     expect(layout.activePart({grid: 'activity.1'})!.id).toEqual('part.activity-1');
     expect(layout.activePart({grid: 'activity.2'})!.id).toEqual('part.activity-2-top');
 
     // Change active part in main grid.
     layout = layout.activatePart('part.outerLeft');
     expect(layout.activePart({grid: 'main'}).id).toEqual('part.outerLeft');
-    expect(layout.activePart({grid: 'mainArea'})!.id).toEqual('part.initial');
+    expect(layout.activePart({grid: 'mainArea'}).id).toEqual('part.initial');
     expect(layout.activePart({grid: 'activity.1'})!.id).toEqual('part.activity-1');
     expect(layout.activePart({grid: 'activity.2'})!.id).toEqual('part.activity-2-top');
 
     // Change active part in main area grid.
     layout = layout.activatePart('part.innerRight');
     expect(layout.activePart({grid: 'main'}).id).toEqual('part.outerLeft');
-    expect(layout.activePart({grid: 'mainArea'})!.id).toEqual('part.innerRight');
+    expect(layout.activePart({grid: 'mainArea'}).id).toEqual('part.innerRight');
     expect(layout.activePart({grid: 'activity.1'})!.id).toEqual('part.activity-1');
     expect(layout.activePart({grid: 'activity.2'})!.id).toEqual('part.activity-2-top');
 
     // Change active part in activity.2 grid.
     layout = layout.activatePart('part.activity-2-bottom');
     expect(layout.activePart({grid: 'main'}).id).toEqual('part.outerLeft');
-    expect(layout.activePart({grid: 'mainArea'})!.id).toEqual('part.innerRight');
+    expect(layout.activePart({grid: 'mainArea'}).id).toEqual('part.innerRight');
     expect(layout.activePart({grid: 'activity.1'})!.id).toEqual('part.activity-1');
     expect(layout.activePart({grid: 'activity.2'})!.id).toEqual('part.activity-2-bottom');
 
     // Change active part in activity.2 grid.
     layout = layout.activatePart('part.activity-2-top');
     expect(layout.activePart({grid: 'main'}).id).toEqual('part.outerLeft');
-    expect(layout.activePart({grid: 'mainArea'})!.id).toEqual('part.innerRight');
+    expect(layout.activePart({grid: 'mainArea'}).id).toEqual('part.innerRight');
     expect(layout.activePart({grid: 'activity.1'})!.id).toEqual('part.activity-1');
     expect(layout.activePart({grid: 'activity.2'})!.id).toEqual('part.activity-2-top');
   });

--- a/projects/scion/workbench/src/lib/layout/workench-layout-serializer.service.spec.ts
+++ b/projects/scion/workbench/src/lib/layout/workench-layout-serializer.service.spec.ts
@@ -104,7 +104,7 @@ describe('WorkbenchLayoutSerializer', () => {
 
     // Expect "migrated" flag to be set.
     expect(layout.grids.main.migrated).toBeTrue();
-    expect(layout.grids.mainArea!.migrated).toBeTrue();
+    expect(layout.grids.mainArea.migrated).toBeTrue();
 
     // Serialize layout.
     const serializedLayout = layout.serialize();
@@ -112,7 +112,7 @@ describe('WorkbenchLayoutSerializer', () => {
 
     // Expect "migrated" flag not to be serialized.
     expect(deserializedLayout.grids.main.migrated).toBeUndefined();
-    expect(deserializedLayout.grids.mainArea!.migrated).toBeUndefined();
+    expect(deserializedLayout.grids.mainArea.migrated).toBeUndefined();
   });
 
   it('should serialize part identifiers into logical identifiers based on their order in the layout', async () => {

--- a/projects/scion/workbench/src/lib/layout/ɵworkbench-layout.ts
+++ b/projects/scion/workbench/src/lib/layout/ɵworkbench-layout.ts
@@ -64,12 +64,6 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
     this._outlets = new Map(Objects.entries(coerceOutlets(config?.outlets)));
     this._navigationStates = new Map(Objects.entries(config?.navigationStates ?? {}));
     this.perspectiveId = config?.perspectiveId;
-
-    // Delete main area grid if not contained in the main grid.
-    if (!this.hasPart(MAIN_AREA, {grid: 'main'})) {
-      delete this._grids.mainArea;
-    }
-
     this.assertActivities();
   }
 
@@ -437,7 +431,7 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
   /**
    * Returns the active part of the specified grid, or `null` if specified grid is not present.
    */
-  public activePart(find: {grid: 'main'}): Readonly<MPart>;
+  public activePart(find: {grid: 'main' | 'mainArea'}): Readonly<MPart>;
   public activePart(find: {grid: keyof WorkbenchGrids}): Readonly<MPart> | null;
   public activePart(find: {grid: keyof WorkbenchGrids}): Readonly<MPart> | null {
     const grid = this._grids[find.grid];
@@ -1304,7 +1298,7 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
       return this.activity({partId}, {orElse: null}) !== null;
     }
     else {
-      return this.hasPart(partId, {grid: 'main'}) && !!this.grids.mainArea;
+      return this.hasPart(partId, {grid: 'main'}) && this.hasPart(MAIN_AREA, {grid: 'main'});
     }
   }
 
@@ -1342,9 +1336,6 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
     const result: T[] = [];
     const gridFilter = options?.grid ? new Set<keyof WorkbenchGrids>(Arrays.coerce(options.grid)) : undefined;
     for (const [gridName, grid] of Objects.entries(this._grids)) {
-      if (!grid) {
-        continue;
-      }
       if (gridFilter && !gridFilter.has(gridName)) {
         continue;
       }

--- a/projects/scion/workbench/src/lib/part/main-area-part/main-area-part.component.ts
+++ b/projects/scion/workbench/src/lib/part/main-area-part/main-area-part.component.ts
@@ -72,10 +72,10 @@ export class MainAreaPartComponent {
   private readonly _logger = inject(Logger);
 
   protected readonly part = inject(ɵWorkbenchPart);
-  protected readonly mainAreaGrid = computed(() => this._layout().grids.mainArea!);
+  protected readonly mainAreaGrid = computed(() => this._layout().grids.mainArea);
   protected readonly desktop = inject(DESKTOP);
   protected readonly dasherize = dasherize;
-  protected readonly canDrop = inject(ViewDragService).canDrop(computed(() => this._layout().grids.mainArea!));
+  protected readonly canDrop = inject(ViewDragService).canDrop(computed(() => this._layout().grids.mainArea));
 
   constructor() {
     inject(ɵWorkbenchPart).partComponent.set(inject(ElementRef).nativeElement as HTMLElement);

--- a/projects/scion/workbench/src/lib/part/part-action-bar/part-action.spec.ts
+++ b/projects/scion/workbench/src/lib/part/part-action-bar/part-action.spec.ts
@@ -117,22 +117,22 @@ describe('PartAction', () => {
 
     // Register action 1.
     TestBed.inject(WorkbenchService).registerPartAction(part => {
-      const partId = part.id as 'part.left' | 'part.right';
-      actionConstructCount[partId].action1++;
-      trackedSignals[partId].action1();
-      return {
-        content: SpecActionComponent,
-      };
+      if (part.id === 'part.left' || part.id === 'part.right') {
+        actionConstructCount[part.id].action1++;
+        trackedSignals[part.id].action1();
+        return SpecActionComponent;
+      }
+      return null;
     });
 
     // Register action 2.
     TestBed.inject(WorkbenchService).registerPartAction(part => {
-      const partId = part.id as 'part.left' | 'part.right';
-      actionConstructCount[partId].action2++;
-      trackedSignals[partId].action2();
-      return {
-        content: SpecActionComponent,
-      };
+      if (part.id === 'part.left' || part.id === 'part.right') {
+        actionConstructCount[part.id].action2++;
+        trackedSignals[part.id].action2();
+        return SpecActionComponent;
+      }
+      return null;
     });
 
     TestBed.tick(); // flush effects
@@ -157,12 +157,13 @@ describe('PartAction', () => {
 
     // Register action 3.
     TestBed.inject(WorkbenchService).registerPartAction(() => {
-      const partId = inject(WorkbenchPart).id as 'part.left' | 'part.right';
-      actionConstructCount[partId].action3++;
-      trackedSignals[partId].action3();
-      return {
-        content: SpecActionComponent,
-      };
+      const part = inject(WorkbenchPart);
+      if (part.id === 'part.left' || part.id === 'part.right') {
+        actionConstructCount[part.id].action3++;
+        trackedSignals[part.id].action3();
+        return SpecActionComponent;
+      }
+      return null;
     });
     TestBed.tick(); // flush effects
 

--- a/projects/scion/workbench/src/lib/routing/routing.util.spec.ts
+++ b/projects/scion/workbench/src/lib/routing/routing.util.spec.ts
@@ -261,7 +261,7 @@ describe('Routing.parseOutlets', () => {
 
     // Add view outlets view.101 and view.103 to the URL.
     await TestBed.inject(ɵWorkbenchRouter).navigate(layout => {
-      const activeMainAreaPart = layout.activePart({grid: 'mainArea'})!;
+      const activeMainAreaPart = layout.activePart({grid: 'mainArea'});
       return layout
         .addView('view.101', {partId: activeMainAreaPart.id})
         .addView('view.102', {partId: activeMainAreaPart.id})

--- a/projects/scion/workbench/src/lib/routing/workbench-router.spec.ts
+++ b/projects/scion/workbench/src/lib/routing/workbench-router.spec.ts
@@ -71,8 +71,8 @@ describe('WorkbenchRouter', () => {
     expect(findActiveMainAreaPart().id).toEqual('part.right');
 
     function findActiveMainAreaPart(): WorkbenchPart {
-      const part = TestBed.inject(ɵWorkbenchService).layout().activePart({grid: 'mainArea'}) ?? throwError('NullActivePart');
-      return TestBed.inject(WorkbenchService).getPart(part.id)!;
+      const activePart = TestBed.inject(ɵWorkbenchService).layout().activePart({grid: 'mainArea'});
+      return TestBed.inject(WorkbenchService).getPart(activePart.id)!;
     }
   });
 
@@ -124,8 +124,8 @@ describe('WorkbenchRouter', () => {
     expect(findActiveMainAreaPart().id).toEqual('part.right');
 
     function findActiveMainAreaPart(): WorkbenchPart {
-      const part = TestBed.inject(ɵWorkbenchService).layout().activePart({grid: 'mainArea'}) ?? throwError('NullActivePart');
-      return TestBed.inject(WorkbenchService).getPart(part.id)!;
+      const activePart = TestBed.inject(ɵWorkbenchService).layout().activePart({grid: 'mainArea'});
+      return TestBed.inject(WorkbenchService).getPart(activePart.id)!;
     }
   });
 

--- a/projects/scion/workbench/src/lib/routing/workbench-url-observer.service.ts
+++ b/projects/scion/workbench/src/lib/routing/workbench-url-observer.service.ts
@@ -311,7 +311,7 @@ export class WorkbenchUrlObserver {
    */
   private migrateURL(): void {
     const layout = this._workbenchRouter.getCurrentNavigationContext().layout;
-    if (layout.grids.mainArea?.migrated) {
+    if (layout.grids.mainArea.migrated) {
       // Update the URL with the migrated URL and clear existing query params, for example, if the layout query parameter has been renamed.
       void this._workbenchRouter.navigate(layout => layout, {queryParamsHandling: null, replaceUrl: true});
     }

--- a/projects/scion/workbench/src/lib/routing/ɵworkbench-router.service.ts
+++ b/projects/scion/workbench/src/lib/routing/ɵworkbench-router.service.ts
@@ -26,6 +26,7 @@ import {WORKBENCH_VIEW_REGISTRY} from '../view/workbench-view.registry';
 import {ɵWorkbenchView} from '../view/ɵworkbench-view.model';
 import {ViewId} from '../view/workbench-view.model';
 import {WorkbenchLayouts} from '../layout/workbench-layouts.util';
+import {MAIN_AREA} from '../layout/workbench-layout';
 
 /** @inheritDoc */
 @Injectable({providedIn: 'root'})
@@ -301,7 +302,7 @@ export function createNavigationFromCommands(commands: Commands, extras: Workben
       if (extras.partId && layout.hasPart(extras.partId)) {
         return extras.partId;
       }
-      return layout.activePart({grid: 'mainArea'})?.id ?? layout.activePart({grid: 'main'}).id;
+      return layout.hasPart(MAIN_AREA) ? layout.activePart({grid: 'mainArea'}).id : layout.activePart({grid: 'main'}).id;
     })();
 
     return layout

--- a/projects/scion/workbench/src/lib/view-dnd/view-drag.service.spec.ts
+++ b/projects/scion/workbench/src/lib/view-dnd/view-drag.service.spec.ts
@@ -64,7 +64,7 @@ describe('ViewDragService', () => {
     simulateViewDrag({viewId: 'view.101'});
 
     // Should allow dropping to main area grid.
-    expect(viewDragService.canDrop(workbenchLayoutService.layout().grids.mainArea!)()).toBeTrue();
+    expect(viewDragService.canDrop(workbenchLayoutService.layout().grids.mainArea)()).toBeTrue();
   });
 
   it('should allow dropping view to different window', async () => {
@@ -293,7 +293,7 @@ describe('ViewDragService', () => {
     simulateViewDrag({viewId: 'view.101'});
 
     // Should not allow dropping to main area grid.
-    expect(viewDragService.canDrop(workbenchLayoutService.layout().grids.mainArea!)()).toBeFalse();
+    expect(viewDragService.canDrop(workbenchLayoutService.layout().grids.mainArea)()).toBeFalse();
   });
 
   function simulateViewDrag(dragSource: {viewId: ViewId}): void {

--- a/projects/scion/workbench/src/lib/view/view-move-handler.service.ts
+++ b/projects/scion/workbench/src/lib/view/view-move-handler.service.ts
@@ -102,7 +102,7 @@ export class ViewMoveHandler {
       const commands = Routing.segmentsToCommands(event.source.navigation?.path ?? []);
       return newLayout
         .addView(newViewId, {
-          partId: newLayout.activePart({grid: 'mainArea'})!.id,
+          partId: newLayout.activePart({grid: 'mainArea'}).id,
           activateView: true,
           cssClass: event.source.classList?.get('layout'),
         })

--- a/projects/scion/workbench/src/lib/view/view.spec.ts
+++ b/projects/scion/workbench/src/lib/view/view.spec.ts
@@ -1039,7 +1039,7 @@ describe('View', () => {
 
     // Add view without navigating it.
     const workbenchRouter = TestBed.inject(ɵWorkbenchRouter);
-    await workbenchRouter.navigate(layout => layout.addView('view.100', {partId: layout.activePart({grid: 'mainArea'})!.id, activateView: true}));
+    await workbenchRouter.navigate(layout => layout.addView('view.100', {partId: layout.activePart({grid: 'mainArea'}).id, activateView: true}));
     await waitUntilStable();
     expect(TestBed.inject(WORKBENCH_VIEW_REGISTRY).get('view.100').getComponent()).toBe(getComponent(fixture, NullContentComponent));
 
@@ -1284,7 +1284,7 @@ describe('View', () => {
     spyOn(console, 'error').and.callThrough().and.callFake((args: unknown[]) => errors.push(...args));
 
     // Open view.
-    await TestBed.inject(ɵWorkbenchRouter).navigate(layout => layout.addView('view.100', {partId: layout.grids.mainArea!.activePartId}));
+    await TestBed.inject(ɵWorkbenchRouter).navigate(layout => layout.addView('view.100', {partId: layout.grids.mainArea.activePartId}));
     await waitUntilStable();
 
     // Navigate view.
@@ -1336,7 +1336,7 @@ describe('View', () => {
     spyOn(console, 'error').and.callThrough().and.callFake((args: unknown[]) => errors.push(...args));
 
     // Open view.
-    await TestBed.inject(ɵWorkbenchRouter).navigate(layout => layout.addView('view.100', {partId: layout.grids.mainArea!.activePartId}));
+    await TestBed.inject(ɵWorkbenchRouter).navigate(layout => layout.addView('view.100', {partId: layout.grids.mainArea.activePartId}));
     await waitUntilStable();
 
     // Navigate view.


### PR DESCRIPTION
Main area content is now preserved across all perspectives, even those without a main area. Previously, it was discarded when switching to perspectives without a main area.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
