### PR TITLE
feat(workbench-client): support placeholders in non-translatable manifest texts

### DIFF
--- a/apps/workbench-testing-app/src/app/workbench.manifest.ts
+++ b/apps/workbench-testing-app/src/app/workbench.manifest.ts
@@ -166,24 +166,7 @@ export const workbenchManifest: Manifest = {
       description: 'Represents a dialog provided by the host app that displays the text test page and has a translatable parameterized title.',
       properties: {
         path: 'test-pages/text-test-page',
-        title: '%dialog_title;id=:id',
-      },
-    } satisfies WorkbenchDialogCapability,
-    // TODO [#271]: Remove this dialog capability when implemented the issue #271
-    {
-      type: WorkbenchCapabilities.Dialog,
-      qualifier: {
-        component: 'host-dialog',
-        variant: 'text-page::translatable-resolved-title',
-      },
-      params: [
-        {name: 'id', required: true},
-      ],
-      private: false,
-      description: 'Represents a dialog provided by the host app that displays the text test page and has a translatable parameterized title with resolved values.',
-      properties: {
-        path: 'test-pages/text-test-page',
-        title: '%dialog_title;id=:id;name=:name',
+        title: '%dialog_title;id=:id;name=:name;undefined=:undefined',
         resolve: {
           name: 'textprovider/workbench-host-app/values/:id',
         },
@@ -194,13 +177,39 @@ export const workbenchManifest: Manifest = {
       type: WorkbenchCapabilities.Dialog,
       qualifier: {
         component: 'host-dialog',
-        variant: 'text-page::translatable-parameterized-title::unkown-param',
+        variant: 'text-page::parameterized-title',
       },
+      params: [
+        {name: 'id', required: true},
+      ],
       private: false,
-      description: 'Represents a dialog provided by the host app that has a translatable title referencing an unkown params.',
+      description: 'Represents a dialog provided by the host app that displays the text test page and has a parameterized title.',
       properties: {
         path: 'test-pages/text-test-page',
-        title: '%dialog_title;id=:id',
+        title: 'Title - :id - :name - :undefined',
+        resolve: {
+          name: 'textprovider/workbench-host-app/values/:id',
+        },
+      },
+    } satisfies WorkbenchDialogCapability,
+    // TODO [#271]: Remove this dialog capability when implemented the issue #271
+    {
+      type: WorkbenchCapabilities.Dialog,
+      qualifier: {
+        component: 'host-dialog',
+        variant: 'text-page::parameterized-title-with-semicolon',
+      },
+      params: [
+        {name: 'id', required: true},
+      ],
+      private: false,
+      description: 'Represents a dialog provided by the host app that displays the text test page and has a parameterized title with a semicolon.',
+      properties: {
+        path: 'test-pages/text-test-page',
+        title: 'Dialog;Title - :id - :name',
+        resolve: {
+          name: 'textprovider/workbench-host-app/values/:id',
+        },
       },
     } satisfies WorkbenchDialogCapability,
     // TODO [#271]: Remove this messagebox capability when implemented the issue #271

--- a/projects/scion/workbench-client/src/lib/dialog/workbench-dialog-capability.ts
+++ b/projects/scion/workbench-client/src/lib/dialog/workbench-dialog-capability.ts
@@ -83,15 +83,32 @@ export interface WorkbenchDialogCapability extends Capability {
     /**
      * Specifies the title of this dialog.
      *
-     * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+     * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
      *
-     * Interpolation parameters can reference capability parameters and resolvers using the colon syntax. Resolvers resolve data based on capability parameters.
-     * See {@link resolve} for defining resolvers.
+     * Text and interpolation parameters can reference capability parameters and resolvers using the colon syntax. See {@link resolve} for defining resolvers.
+     *
+     * @example - Title referencing a resolver
      *
      * ```json
      * {
      *   "params": [
-     *     {"name": "id", "required":  true}
+     *     {"name": "id", "required": true}
+     *   ],
+     *   "properties": {
+     *     "title": ":productName", // `:productName` references a resolver
+     *     "resolve": {
+     *       "productName": "products/:id/name" // `:id` references a capability parameter
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * @example - Translatable title referencing a resolver in its interpolation parameters
+     *
+     * ```json
+     * {
+     *   "params": [
+     *     {"name": "id", "required": true}
      *   ],
      *   "properties": {
      *     "title": "%product.title;name=:productName", // `:productName` references a resolver
@@ -104,26 +121,25 @@ export interface WorkbenchDialogCapability extends Capability {
      */
     title?: Translatable;
     /**
-     * Specifies data resolvers for use in the dialog title.
+     * Defines resolvers for use in the dialog title.
      *
-     * A resolver defines a topic where a request is sent to resolve data. Topic segments can reference capability parameters using the colon syntax.
-     * Resolvers can be referenced in interpolation parameters of {@link title} using the colon syntax.
+     * A resolver defines a topic where a request is sent to resolve text or a translation key, typically based on capability parameters. Topic segments can reference capability parameters using the colon syntax.
      *
-     * ```json
-     * {
-     *   "params": [
-     *     {"name": "id", "required":  true}
-     *   ],
-     *   "properties": {
-     *     "title": "%product.title;name=:productName", // `:productName` references a resolver
-     *     "resolve": {
-     *       "productName": "products/:id/name" // `:id` references a capability parameter
-     *     }
-     *   }
-     * }
+     * The application can respond to resolve requests by installing a message listener in the activator. Refer to {@link ActivatorCapability} for registering an activator.
+     *
+     * @example - Message listener replying to resolve requests
+     *
+     * ```ts
+     * import {Beans} from '@scion/toolkit/bean-manager';
+     * import {MessageClient} from '@scion/microfrontend-platform';
+     *
+     * Beans.get(MessageClient).onMessage('products/:id/name', message => {
+     *   const id = message.params.get('id');
+     *   return `Product ${id}`;
+     * });
      * ```
      */
-    resolve?: {[key: string]: string};
+    resolve?: {[key: string]: Translatable};
     /**
      * Specifies if to display a close button in the dialog header. Defaults to `true`.
      */

--- a/projects/scion/workbench-client/src/lib/dialog/workbench-dialog.ts
+++ b/projects/scion/workbench-client/src/lib/dialog/workbench-dialog.ts
@@ -43,7 +43,7 @@ export abstract class WorkbenchDialog<R = unknown> {
   /**
    * Sets the title of the dialog.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   public abstract setTitle(title: Translatable): void;
 

--- a/projects/scion/workbench-client/src/lib/message-box/workbench-message-box-service.ts
+++ b/projects/scion/workbench-client/src/lib/message-box/workbench-message-box-service.ts
@@ -43,7 +43,7 @@ export abstract class WorkbenchMessageBoxService {
    * **This API requires the following intention: `{"type": "messagebox"}`**
    *
    * @param message - Specifies the text to display, if any.
-   *                  Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   *                  Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    * @param options - Controls the appearance and behavior of the message box.
    * @returns Promise that resolves to the key of the action button that the user clicked to close the message box,
    *          or that rejects if the message box couldn't be opened, e.g., because of missing the intention.

--- a/projects/scion/workbench-client/src/lib/message-box/workbench-message-box.options.ts
+++ b/projects/scion/workbench-client/src/lib/message-box/workbench-message-box.options.ts
@@ -21,7 +21,7 @@ export interface WorkbenchMessageBoxOptions {
   /**
    * Specifies the title of the message box.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   title?: Translatable;
 
@@ -29,7 +29,7 @@ export interface WorkbenchMessageBoxOptions {
    * Defines buttons of the message box. If not set, an OK button is displayed by default.
    *
    * Each property in the object literal represents a button, with the property value used as the button label.
-   * The label can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * The label can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    *
    * Clicking a button closes the message box and returns the property key to the message box opener.
    *

--- a/projects/scion/workbench-client/src/lib/notification/workbench-notification.config.ts
+++ b/projects/scion/workbench-client/src/lib/notification/workbench-notification.config.ts
@@ -27,7 +27,7 @@ export interface WorkbenchNotificationConfig {
   /**
    * Specifies the title of the notification.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   title?: Translatable;
 

--- a/projects/scion/workbench-client/src/lib/text/workbench-text-provider.model.ts
+++ b/projects/scion/workbench-client/src/lib/text/workbench-text-provider.model.ts
@@ -58,6 +58,8 @@ export interface WorkbenchTextProviderCapability extends Capability {
  * Key and parameters are passed to the registered text provider for translation. Applications can register a text provider
  * using {@link WorkbenchClient.registerTextProvider}.
  *
+ * Semicolons in interpolation parameters must be escaped with two backslashes (`\\;`).
+ *
  * Examples:
  * - `%key`: translation key
  * - `%key;param=value`: translation key with a single interpolation parameter

--- a/projects/scion/workbench-client/src/lib/text/ɵworkbench-text-service.ts
+++ b/projects/scion/workbench-client/src/lib/text/ɵworkbench-text-service.ts
@@ -105,23 +105,23 @@ function parseMatrixParams(matrixParams: string | undefined): Record<string, str
   }
 
   const params: Record<string, string> = {};
-  for (const match of escapeSemicolon(matrixParams).matchAll(/(?<paramName>[^=;]+)=(?<paramValue>[^;]*)/g)) {
-    const {paramName, paramValue} = match.groups!;
-    params[unescapeSemicolon(paramName!)] = unescapeSemicolon(paramValue!);
+  for (const match of encodeEscapedSemicolons(matrixParams).matchAll(/(?<paramName>[^=;]+)=(?<paramValue>[^;]*)/g)) {
+    const {paramName, paramValue} = match.groups as {paramName: string; paramValue: string};
+    params[paramName] = decodeSemicolons(paramValue);
   }
   return params;
 
   /**
-   * Replaces escaped semicolons (`\;`) with the placeholder (`ɵ`) to prevent interpretation as key-value separators.
+   * Encodes escaped semicolons (`\\;`) as `&#x3b` (Unicode) to prevent interpretation as interpolation parameter separators.
    */
-  function escapeSemicolon(value: string): string {
-    return value.replaceAll('\\;', 'ɵ');
+  function encodeEscapedSemicolons(value: string): string {
+    return value.replaceAll('\\;', '&#x3b');
   }
 
   /**
-   * Restores escaped semicolons by replacing the placeholder (`ɵ`) back to semicolons (`;`).
+   * Decodes encoded semicolons (`&#x3b`) back to semicolons (`;`).
    */
-  function unescapeSemicolon(value: string): string {
-    return value.replaceAll('ɵ', ';');
+  function decodeSemicolons(value: string): string {
+    return value.replaceAll('&#x3b', ';');
   }
 }

--- a/projects/scion/workbench-client/src/lib/view/workbench-view-capability.ts
+++ b/projects/scion/workbench-client/src/lib/view/workbench-view-capability.ts
@@ -75,17 +75,34 @@ export interface WorkbenchViewCapability extends Capability {
      */
     lazy?: boolean;
     /**
-     * Specifies the title displayed in the view tab.
+     * Specifies the title of the view tab.
      *
-     * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+     * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
      *
-     * Interpolation parameters can reference capability parameters and resolvers using the colon syntax. Resolvers resolve data based on capability parameters.
-     * See {@link resolve} for defining resolvers.
+     * Text and interpolation parameters can reference capability parameters and resolvers using the colon syntax. See {@link resolve} for defining resolvers.
+     *
+     * @example - Title referencing a resolver
      *
      * ```json
      * {
      *   "params": [
-     *     {"name": "id", "required":  true}
+     *     {"name": "id", "required": true}
+     *   ],
+     *   "properties": {
+     *     "title": ":productName", // `:productName` references a resolver
+     *     "resolve": {
+     *       "productName": "products/:id/name" // `:id` references a capability parameter
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * @example - Translatable title referencing a resolver in its interpolation parameters
+     *
+     * ```json
+     * {
+     *   "params": [
+     *     {"name": "id", "required": true}
      *   ],
      *   "properties": {
      *     "title": "%product.title;name=:productName", // `:productName` references a resolver
@@ -98,22 +115,39 @@ export interface WorkbenchViewCapability extends Capability {
      */
     title?: Translatable;
     /**
-     * Specifies the subtitle displayed in the view tab.
+     * Specifies the subtitle of the view tab.
      *
-     * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+     * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
      *
-     * Interpolation parameters can reference capability parameters and resolvers using the colon syntax. Resolvers resolve data based on capability parameters.
-     * See {@link resolve} for defining resolvers.
+     * Text and interpolation parameters can reference capability parameters and resolvers using the colon syntax. See {@link resolve} for defining resolvers.
+     *
+     * @example - Heading referencing a resolver
      *
      * ```json
      * {
      *   "params": [
-     *     {"name": "id", "required":  true}
+     *     {"name": "id", "required": true}
      *   ],
      *   "properties": {
-     *     "heading": "%product_category.title;category=:categoryName", // `:categoryName` references a resolver
+     *     "heading": ":productCategory", // `:productCategory` references a resolver
      *     "resolve": {
-     *       "categoryName": "products/:id/category" // `:id` references a capability parameter
+     *      "productCategory": "products/:id/category" // `:id` references a capability parameter
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * @example - Translatable heading referencing a resolver in its interpolation parameters
+     *
+     * ```json
+     * {
+     *   "params": [
+     *     {"name": "id", "required": true}
+     *   ],
+     *   "properties": {
+     *     "heading": "%product_category.title;category=:productCategory", // `:productCategory` references a resolver
+     *     "resolve": {
+     *       "productCategory": "products/:id/category" // `:id` references a capability parameter
      *     }
      *   }
      * }
@@ -121,26 +155,25 @@ export interface WorkbenchViewCapability extends Capability {
      */
     heading?: Translatable;
     /**
-     * Specifies data resolvers for use in the view title and heading.
+     * Defines resolvers for use in the view title and heading.
      *
-     * A resolver defines a topic where a request is sent to resolve data. Topic segments can reference capability parameters using the colon syntax.
-     * Resolvers can be referenced in interpolation parameters of {@link title} and {@link heading} using the colon syntax.
+     * A resolver defines a topic where a request is sent to resolve text or a translation key, typically based on capability parameters. Topic segments can reference capability parameters using the colon syntax.
      *
-     * ```json
-     * {
-     *   "params": [
-     *     {"name": "id", "required":  true}
-     *   ],
-     *   "properties": {
-     *     "title": "%product.title;name=:productName", // `:productName` references a resolver
-     *     "resolve": {
-     *       "productName": "products/:id" // `:id` references a capability parameter
-     *     }
-     *   }
-     * }
+     * The application can respond to resolve requests by installing a message listener in the activator. Refer to {@link ActivatorCapability} for registering an activator.
+     *
+     * @example - Message listener replying to resolve requests
+     *
+     * ```ts
+     * import {Beans} from '@scion/toolkit/bean-manager';
+     * import {MessageClient} from '@scion/microfrontend-platform';
+     *
+     * Beans.get(MessageClient).onMessage('products/:id/name', message => {
+     *   const id = message.params.get('id');
+     *   return `Product ${id}`;
+     * });
      * ```
      */
-    resolve?: {[key: string]: string};
+    resolve?: {[key: string]: Translatable};
     /**
      * Controls if to display a close button in the view tab. Defaults to `true`.
      */

--- a/projects/scion/workbench-client/src/lib/view/workbench-view.ts
+++ b/projects/scion/workbench-client/src/lib/view/workbench-view.ts
@@ -92,7 +92,7 @@ export abstract class WorkbenchView {
   /**
    * Sets the title to be displayed in the view tab.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   public abstract setTitle(title: Translatable): void;
 
@@ -106,7 +106,7 @@ export abstract class WorkbenchView {
   /**
    * Sets the subtitle to be displayed in the view tab.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   public abstract setHeading(heading: Translatable): void;
 

--- a/projects/scion/workbench/src/lib/dialog/workbench-dialog.ts
+++ b/projects/scion/workbench/src/lib/dialog/workbench-dialog.ts
@@ -29,7 +29,7 @@ export abstract class WorkbenchDialog<R = unknown> {
   /**
    * Sets the title of the dialog.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   public abstract get title(): Signal<Translatable | undefined>;
   public abstract set title(title: Translatable | undefined);

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.ts
@@ -263,7 +263,7 @@ export interface PartExtras {
   /**
    * Title displayed in the part bar.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   title?: Translatable;
   /**
@@ -302,13 +302,13 @@ export interface DockedPartExtras {
   /**
    * Label of the toggle button in the sidebar.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   label: Translatable;
   /**
    * Tooltip displayed when hovering over the toggle button in the sidebar.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   tooltip?: Translatable;
   /**
@@ -316,7 +316,7 @@ export interface DockedPartExtras {
    *
    * If not provided, defaults to {@link DockedPartExtras.label}. Set to `false` to not display a title.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   title?: Translatable | false;
   /**

--- a/projects/scion/workbench/src/lib/message-box/workbench-message-box.options.ts
+++ b/projects/scion/workbench/src/lib/message-box/workbench-message-box.options.ts
@@ -19,7 +19,7 @@ export interface WorkbenchMessageBoxOptions {
   /**
    * Specifies the title of the message box.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   title?: Translatable;
 

--- a/projects/scion/workbench/src/lib/message-box/workbench-message-box.service.ts
+++ b/projects/scion/workbench/src/lib/message-box/workbench-message-box.service.ts
@@ -62,7 +62,7 @@ export abstract class WorkbenchMessageBoxService {
    * ```
    *
    * @param  message - Specifies the text to display, if any.
-   *                   Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   *                   Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    * @param options - Controls the appearance and behavior of the message box.
    * @return Promise that resolves to the key of the action button that the user clicked to close the message box.
    */

--- a/projects/scion/workbench/src/lib/microfrontend-platform/text/host-text-provider.ts
+++ b/projects/scion/workbench/src/lib/microfrontend-platform/text/host-text-provider.ts
@@ -25,7 +25,7 @@ export function provideHostTextProvider(): EnvironmentProviders {
       const injector = inject(Injector);
 
       WorkbenchClient.registerTextProvider((key, params) => {
-        const translatable = Object.entries(params).reduce((translatable, [name, value]) => `${translatable};${name}=${value}`, `%${key}`);
+        const translatable = Object.entries(params).reduce((translatable, [name, value]) => `${translatable};${name}=${encodeSemicolons(value)}`, `%${key}`);
         const environmentInjector = createEnvironmentInjector([], injector.get(EnvironmentInjector));
 
         return toObservable(text(translatable, {injector: environmentInjector}), {injector: environmentInjector})
@@ -36,4 +36,13 @@ export function provideHostTextProvider(): EnvironmentProviders {
       });
     }),
   ]);
+}
+
+/**
+ * Encodes semicolons (`;`) as `\\;` to prevent interpretation as interpolation parameter separators.
+ *
+ * @see Translatable
+ */
+function encodeSemicolons(value: string): string {
+  return value.replaceAll(';', '\\;');
 }

--- a/projects/scion/workbench/src/lib/microfrontend-platform/text/remote-text-provider.spec.ts
+++ b/projects/scion/workbench/src/lib/microfrontend-platform/text/remote-text-provider.spec.ts
@@ -14,114 +14,159 @@ describe('RemoteTextProvider', () => {
 
   describe('createRemoteTranslatable', () => {
 
-    it('should return non-translatable text as is', () => {
+    it('should return text as-is', () => {
       const translatable = createRemoteTranslatable('text', {appSymbolicName: 'app'});
       expect(translatable).toEqual('text');
     });
 
     it('should add app to key', () => {
       const translatable = createRemoteTranslatable('%key', {appSymbolicName: 'app'});
-      expect(translatable).toEqual('%workbench.external.~app~.key');
+      expect(translatable).toEqual('%workbench.external.scion-workbench-client.app.%key');
     });
 
     it('should include params', () => {
       const translatable = createRemoteTranslatable('%key;param1=value1;param2=value2', {appSymbolicName: 'app'});
-      expect(translatable).toEqual('%workbench.external.~app~.key;param1=value1;param2=value2');
+      expect(translatable).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=value1;param2=value2');
     });
 
     it('should substitute named interpolation parameters', () => {
       const translatable1 = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', valueParams: {value1: 'VALUE1'}});
-      expect(translatable1).toEqual('%workbench.external.~app~.key;param1=VALUE1;param2=value2');
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=VALUE1;param2=value2');
 
       const translatable2 = createRemoteTranslatable('%key;param1=value1;param2=:value2', {appSymbolicName: 'app', valueParams: {value2: 'VALUE2'}});
-      expect(translatable2).toEqual('%workbench.external.~app~.key;param1=value1;param2=VALUE2');
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=value1;param2=VALUE2');
 
       const translatable3 = createRemoteTranslatable('%key;param1=:value1;param2=:value2', {appSymbolicName: 'app', valueParams: {value1: 'VALUE1', value2: 'VALUE2'}});
-      expect(translatable3).toEqual('%workbench.external.~app~.key;param1=VALUE1;param2=VALUE2');
+      expect(translatable3).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=VALUE1;param2=VALUE2');
     });
 
     it('should not substitute unkown named interpolation parameters', () => {
       const translatable1 = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app'});
-      expect(translatable1).toEqual('%workbench.external.~app~.key;param1=:value1;param2=value2');
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=:value1;param2=value2');
 
       const translatable2 = createRemoteTranslatable('%key;param1=value1;param2=:value2', {appSymbolicName: 'app'});
-      expect(translatable2).toEqual('%workbench.external.~app~.key;param1=value1;param2=:value2');
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=value1;param2=:value2');
     });
 
     it('should not substitute partial named interpolation parameters', () => {
       const translatable1 = createRemoteTranslatable('%key;param1=abc:value1;param2=:value2', {appSymbolicName: 'app', valueParams: {value1: 'VALUE1', value2: 'VALUE2'}});
-      expect(translatable1).toEqual('%workbench.external.~app~.key;param1=abc:value1;param2=VALUE2');
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=abc:value1;param2=VALUE2');
 
       const translatable2 = createRemoteTranslatable('%key;param1=:value1abc;param2=:value2', {appSymbolicName: 'app', valueParams: {value1: 'VALUE1', value2: 'VALUE2'}});
-      expect(translatable2).toEqual('%workbench.external.~app~.key;param1=:value1abc;param2=VALUE2');
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=:value1abc;param2=VALUE2');
 
       const translatable3 = createRemoteTranslatable('%key;param1=:value1;param2=abc:value2', {appSymbolicName: 'app', valueParams: {value1: 'VALUE1', value2: 'VALUE2'}});
-      expect(translatable3).toEqual('%workbench.external.~app~.key;param1=VALUE1;param2=abc:value2');
+      expect(translatable3).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=VALUE1;param2=abc:value2');
 
       const translatable4 = createRemoteTranslatable('%key;param1=:value1;param2=:value2abc', {appSymbolicName: 'app', valueParams: {value1: 'VALUE1', value2: 'VALUE2'}});
-      expect(translatable4).toEqual('%workbench.external.~app~.key;param1=VALUE1;param2=:value2abc');
+      expect(translatable4).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=VALUE1;param2=:value2abc');
     });
 
     it('should not substitute named interpolation parameter keys', () => {
       const translatable1 = createRemoteTranslatable('%key;:param1=value1;param2=value2', {appSymbolicName: 'app', valueParams: {param1: 'PARAM1'}});
-      expect(translatable1).toEqual('%workbench.external.~app~.key;:param1=value1;param2=value2');
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.%key;:param1=value1;param2=value2');
 
       const translatable2 = createRemoteTranslatable('%key;param1=value1;:param2=value2', {appSymbolicName: 'app', valueParams: {param2: 'PARAM2'}});
-      expect(translatable2).toEqual('%workbench.external.~app~.key;param1=value1;:param2=value2');
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=value1;:param2=value2');
     });
 
     it('should substitute named topic interpolation parameters', () => {
       const translatable = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', topicParams: {value1: 'a/b/c'}});
-      expect(translatable).toEqual('%workbench.external.~app~.key;param1=topic://a/b/c;param2=value2');
+      expect(translatable).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://a/b/c;param2=value2');
     });
 
     it('should not substitute partial named topic interpolation parameters', () => {
       const translatable1 = createRemoteTranslatable('%key;param1=abc:value1;param2=:value2', {appSymbolicName: 'app', topicParams: {value1: 'a/b/c', value2: 'd/e/f'}});
-      expect(translatable1).toEqual('%workbench.external.~app~.key;param1=abc:value1;param2=topic://d/e/f');
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=abc:value1;param2=topic://d/e/f');
 
       const translatable2 = createRemoteTranslatable('%key;param1=:value1abc;param2=:value2', {appSymbolicName: 'app', topicParams: {value1: 'a/b/c', value2: 'd/e/f'}});
-      expect(translatable2).toEqual('%workbench.external.~app~.key;param1=:value1abc;param2=topic://d/e/f');
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=:value1abc;param2=topic://d/e/f');
 
       const translatable3 = createRemoteTranslatable('%key;param1=:value1;param2=abc:value2', {appSymbolicName: 'app', topicParams: {value1: 'a/b/c', value2: 'd/e/f'}});
-      expect(translatable3).toEqual('%workbench.external.~app~.key;param1=topic://a/b/c;param2=abc:value2');
+      expect(translatable3).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://a/b/c;param2=abc:value2');
 
       const translatable4 = createRemoteTranslatable('%key;param1=:value1;param2=:value2abc', {appSymbolicName: 'app', topicParams: {value1: 'a/b/c', value2: 'd/e/f'}});
-      expect(translatable4).toEqual('%workbench.external.~app~.key;param1=topic://a/b/c;param2=:value2abc');
+      expect(translatable4).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://a/b/c;param2=:value2abc');
     });
 
     it('should not substitute named topic interpolation parameter keys', () => {
       const translatable1 = createRemoteTranslatable('%key;:param1=value1;param2=value2', {appSymbolicName: 'app', topicParams: {param1: 'a/b/c'}});
-      expect(translatable1).toEqual('%workbench.external.~app~.key;:param1=value1;param2=value2');
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.%key;:param1=value1;param2=value2');
 
       const translatable2 = createRemoteTranslatable('%key;param1=value1;:param2=value2', {appSymbolicName: 'app', topicParams: {param2: 'd/e/f'}});
-      expect(translatable2).toEqual('%workbench.external.~app~.key;param1=value1;:param2=value2');
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=value1;:param2=value2');
     });
 
     it('should substitute named topic segments', () => {
       const translatable1 = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', valueParams: {entity: 'ENTITY'}, topicParams: {value1: ':entity/b/c'}});
-      expect(translatable1).toEqual('%workbench.external.~app~.key;param1=topic://ENTITY/b/c;param2=value2');
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://ENTITY/b/c;param2=value2');
 
       const translatable2 = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', valueParams: {id: 'ID'}, topicParams: {value1: 'a/:id/c'}});
-      expect(translatable2).toEqual('%workbench.external.~app~.key;param1=topic://a/ID/c;param2=value2');
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://a/ID/c;param2=value2');
     });
 
     it('should not substitute unkown named topic segments', () => {
       const translatable = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', topicParams: {value1: 'a/:id/c'}});
-      expect(translatable).toEqual('%workbench.external.~app~.key;param1=topic://a/:id/c;param2=value2');
+      expect(translatable).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://a/:id/c;param2=value2');
     });
 
     it('should not substitute partial named topic segments', () => {
       const translatable1 = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', valueParams: {id: 'ID'}, topicParams: {value1: 'a:id/b/c'}});
-      expect(translatable1).toEqual('%workbench.external.~app~.key;param1=topic://a:id/b/c;param2=value2');
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://a:id/b/c;param2=value2');
 
       const translatable2 = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', valueParams: {id: 'ID'}, topicParams: {value1: ':ida/b/c'}});
-      expect(translatable2).toEqual('%workbench.external.~app~.key;param1=topic://:ida/b/c;param2=value2');
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://:ida/b/c;param2=value2');
 
       const translatable3 = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', valueParams: {id: 'ID'}, topicParams: {value1: 'a/b:id/c'}});
-      expect(translatable3).toEqual('%workbench.external.~app~.key;param1=topic://a/b:id/c;param2=value2');
+      expect(translatable3).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://a/b:id/c;param2=value2');
 
       const translatable4 = createRemoteTranslatable('%key;param1=:value1;param2=value2', {appSymbolicName: 'app', valueParams: {id: 'ID'}, topicParams: {value1: 'a/:idb/c'}});
-      expect(translatable4).toEqual('%workbench.external.~app~.key;param1=topic://a/:idb/c;param2=value2');
+      expect(translatable4).toEqual('%workbench.external.scion-workbench-client.app.%key;param1=topic://a/:idb/c;param2=value2');
+    });
+
+    it('should append parameters to non-translatable text', () => {
+      const translatable1a = createRemoteTranslatable(':id', {appSymbolicName: 'app', valueParams: {id: '123'}});
+      expect(translatable1a).toEqual('%workbench.external.scion-workbench-client.app.:id;id=123');
+
+      const translatable1b = createRemoteTranslatable('Start :id End', {appSymbolicName: 'app', valueParams: {id: '123'}});
+      expect(translatable1b).toEqual('%workbench.external.scion-workbench-client.app.Start :id End;id=123');
+
+      const translatable2a = createRemoteTranslatable(':name', {appSymbolicName: 'app', topicParams: {name: 'a/b/c'}});
+      expect(translatable2a).toEqual('%workbench.external.scion-workbench-client.app.:name;name=topic://a/b/c');
+
+      const translatable2b = createRemoteTranslatable('Start :name End', {appSymbolicName: 'app', topicParams: {name: 'a/b/c'}});
+      expect(translatable2b).toEqual('%workbench.external.scion-workbench-client.app.Start :name End;name=topic://a/b/c');
+
+      const translatable3a = createRemoteTranslatable(':name', {appSymbolicName: 'app', valueParams: {id: '123'}, topicParams: {name: 'a/:id/c'}});
+      expect(translatable3a).toEqual('%workbench.external.scion-workbench-client.app.:name;name=topic://a/123/c');
+
+      const translatable3b = createRemoteTranslatable('Start :name End', {appSymbolicName: 'app', valueParams: {id: '123'}, topicParams: {name: 'a/:id/c'}});
+      expect(translatable3b).toEqual('%workbench.external.scion-workbench-client.app.Start :name End;name=topic://a/123/c');
+
+      const translatable4a = createRemoteTranslatable(':param', {appSymbolicName: 'app'});
+      expect(translatable4a).toEqual(':param');
+
+      const translatable4b = createRemoteTranslatable(':param1 :param2 :param3', {appSymbolicName: 'app', valueParams: {param1: '123', param4: '456'}, topicParams: {param2: 'a/b/c'}});
+      expect(translatable4b).toEqual('%workbench.external.scion-workbench-client.app.:param1 :param2 :param3;param1=123;param2=topic://a/b/c');
+    });
+
+    it('should escape semicolon in non-translatable text', () => {
+      const translatable1 = createRemoteTranslatable('A;B', {appSymbolicName: 'app'});
+      expect(translatable1).toEqual('A;B');
+
+      const translatable2 = createRemoteTranslatable('A;:param;B', {appSymbolicName: 'app'});
+      expect(translatable2).toEqual('A;:param;B');
+
+      const translatable3 = createRemoteTranslatable('A;:param;B', {appSymbolicName: 'app', valueParams: {param: 'value'}});
+      expect(translatable3).toEqual('%workbench.external.scion-workbench-client.app.A&#x3b:param&#x3bB;param=value');
+    });
+
+    it('should escape semicolon in parameters', () => {
+      const translatable1 = createRemoteTranslatable(':param', {valueParams: {param: '123;456'}, appSymbolicName: 'app'});
+      expect(translatable1).toEqual('%workbench.external.scion-workbench-client.app.:param;param=123&#x3b456');
+
+      const translatable2 = createRemoteTranslatable('%key;param=:param', {valueParams: {param: '123;456'}, appSymbolicName: 'app'});
+      expect(translatable2).toEqual('%workbench.external.scion-workbench-client.app.%key;param=123&#x3b456');
     });
   });
 });

--- a/projects/scion/workbench/src/lib/microfrontend-platform/text/remote-text-provider.ts
+++ b/projects/scion/workbench/src/lib/microfrontend-platform/text/remote-text-provider.ts
@@ -13,63 +13,95 @@ import {EnvironmentProviders, makeEnvironmentProviders, Signal} from '@angular/c
 import {toSignal} from '@angular/core/rxjs-interop';
 import {combineLatest, map, Observable, of, switchMap} from 'rxjs';
 import {Beans} from '@scion/toolkit/bean-manager';
-import {MessageClient} from '@scion/microfrontend-platform';
+import {mapToBody, MessageClient} from '@scion/microfrontend-platform';
 import {WorkbenchTextService} from '@scion/workbench-client';
 import {Dictionaries} from '@scion/toolkit/util';
 
 /**
  * Registers a text provider for the SCION Workbench to get texts from micro apps.
  *
- * If the key matches the format of a remote key, text is requested via intent from the respective 'text-provider' capability.
- * If not, the key is ignored and `undefined` is returned.
- *
- * Remote key format: "workbench.external.~<APP_SYMBOLIC_NAME>~.<TEXT_KEY>".
+ * This text provider provides texts for keys matching the format: "workbench.external.scion-workbench-client.<APP_SYMBOLIC_NAME>.<TRANSLATABLE>".
  *
  * @see createRemoteTranslatable
  */
 export function provideRemoteTextProvider(): EnvironmentProviders {
-  const REMOTE_KEY = /^workbench\.external\.~(?<provider>[^\\~]+)~\.(?<key>.+)$/;
+  const REMOTE_TRANSLATION_KEY = /^workbench\.external\.scion-workbench-client\.(?<provider>[^\\.]+)\.%(?<key>.+)$/;
+  const REMOTE_TEXT = /^workbench\.external\.scion-workbench-client\.(?<provider>[^\\.]+)\.(?<text>[^%].+)$/;
+
   return makeEnvironmentProviders([
     {
       provide: WORKBENCH_TEXT_PROVIDER,
-      useValue: remoteTextProvider satisfies WorkbenchTextProviderFn,
+      useValue: provideRemoteText satisfies WorkbenchTextProviderFn,
+      multi: true,
+    },
+    {
+      provide: WORKBENCH_TEXT_PROVIDER,
+      useValue: interpolateRemoteText satisfies WorkbenchTextProviderFn,
       multi: true,
     },
   ]);
 
-  function remoteTextProvider(remoteKey: string | `workbench.external.~${string}~.${string}`, params: {[name: string]: string | `topic://${string}`}): Signal<string> | undefined {
-    // Test if the key matches a remote key.
-    const match = REMOTE_KEY.exec(remoteKey);
+  /**
+   * Provides text from a remote app.
+   */
+  function provideRemoteText(translationKey: string | `workbench.external.scion-workbench-client.${string}.%${string}`, params: {[name: string]: string | `topic://${string}`}): Signal<string> | undefined {
+    // Test if the key matches a remote translation key.
+    const match = REMOTE_TRANSLATION_KEY.exec(translationKey);
     if (!match) {
-      return undefined; // ignore key
+      return undefined;
     }
 
-    // Parse key and provider from the remote key.
-    const {key, provider} = match.groups!;
+    // Parse key and provider from the remote translation key.
+    const {key, provider} = match.groups as {key: string; provider: string};
 
     // Request the text by intent. Parameters starting with the topic protocol 'topic://' are resolved via messaging.
-    const text$ = observeParams$(params)
+    const text$ = observeParams$(params, {provider})
       .pipe(
-        map(params => params.reduce((translatable, [name, value]) => `${translatable};${name}=${value}`, `%${key!}`)),
-        switchMap(translatable => Beans.get(WorkbenchTextService).text$(translatable, {provider: provider!})),
-        map(text => text ?? key!),
+        map(params => params.reduce((translatable, [param, value]) => `${translatable};${param}=${encodeSemicolons(value)}`, `%${key}`)),
+        switchMap(translatable => Beans.get(WorkbenchTextService).text$(translatable, {provider})),
+        map(text => text ?? key),
       );
     return toSignal(text$, {initialValue: ''});
   }
 
   /**
-   * Creates an Observable that emits tuples of name/value pairs from the passed parameters.
+   * Substitutes named parameters in a remote text.
+   */
+  function interpolateRemoteText(translationKey: string | `workbench.external.scion-workbench-client.${string}.${string}`, params: {[name: string]: string | `topic://${string}`}): Signal<string> | undefined {
+    // Test if the key matches a remote text.
+    const match = REMOTE_TEXT.exec(translationKey);
+    if (!match) {
+      return undefined;
+    }
+
+    // Parse text and provider from the remote text.
+    const {text, provider} = match.groups as {text: string; provider: string};
+
+    // Substitute params. Parameters starting with the topic protocol 'topic://' are resolved via messaging.
+    const text$ = observeParams$(params, {provider})
+      .pipe(map(params => params.reduce((text, [param, value]) => text.replaceAll(`:${param}`, value), decodeSemicolons(text))));
+    return toSignal(text$, {initialValue: ''});
+  }
+
+  /**
+   * Creates an Observable that emits tuples of name-value pairs from the passed parameters.
    *
    * Parameters starting with the topic protocol 'topic://' are resolved via topic-based messaging.
    */
-  function observeParams$(params: {[name: string]: string | `topic://${string}`}): Observable<Array<[string, string]>> {
-    const observableParams: Array<Observable<[string, string]>> = Object.entries(params).map(([name, value]) => {
+  function observeParams$(params: {[name: string]: string | `topic://${string}`}, options: {provider: string}): Observable<Array<[string, string]>> {
+    const observableParams: Array<Observable<[string, string]>> = Object.entries(params).map(([param, value]) => {
       if (!value.startsWith(TOPIC_PROTOCOL)) {
-        return of([name, value]);
+        return of([param, value]);
       }
 
       const topic = value.substring(TOPIC_PROTOCOL.length);
-      return Beans.get(MessageClient).request$<string | undefined>(topic, undefined, {retain: true}).pipe(map(({body: resolved}) => ([name, resolved ?? ''])));
+      return Beans.get(MessageClient).request$<Translatable | undefined>(topic, undefined, {retain: true})
+        .pipe(
+          mapToBody(),
+          // Resolve text if the resolver returns a translatable.
+          switchMap(resolved => resolved?.startsWith('%') ? Beans.get(WorkbenchTextService).text$(resolved, options) : of(resolved)),
+          map(resolved => [param, resolved ?? '']),
+        );
     });
 
     return observableParams.length ? combineLatest(observableParams) : of([]);
@@ -79,38 +111,82 @@ export function provideRemoteTextProvider(): EnvironmentProviders {
 /**
  * Creates a translatable for the SCION Workbench to request the text from a micro app.
  *
- * Passed parameters are used to substitute named interpolation parameters. A named interpolation parameter starts with a colon (`:`) followed by a name.
+ * Passed parameters are used to substitute named parameters in the text or interpolation parameters of the translation key.
  *
- * Example: %translationKey;param1=value1;param2=:value2 // :value2 is a named interpolation parameter
+ * A named parameter starts with a colon (`:`) followed by the parameter name and can be substituted by an explicit value (passed as value param) or topic (passed as topic param).
+ * Topic params define a topic with the actual value requested when resolving the translatable. A topic can also reference value params as named params in topic segments.
  *
- * Named interpolation parameters can be substituted by explicit values (passed as value params) or topics (passed as topic params).
- * Unlike value params, topic params define a topic and the actual value will be requested when resolving the translatable.
- * Like the translatable's interpolation params, a topic can reference value params as named parameters in topic segments.
+ * @example - Translation Key
+ * `%translationKey;param1=:namedParam1;param2=:namedParam2`
+ *
+ * @example - Text
+ * `Text with :namedParam1 and :namedParam2`
  *
  * @param translatable - Specifies the translatable.
- * @param config - Specifies the text provider and values for substituting named interpolation parameters.
+ * @param config - Specifies the text provider and values for substituting named parameters.
  * @return Translatable that can be passed to the workbench's {@link text()} function for translation.
  *
  * @see provideRemoteTextProvider
  */
 export function createRemoteTranslatable(translatable: Translatable | undefined, config: {appSymbolicName: string; valueParams?: {[name: string]: unknown} | Map<string, unknown>; topicParams?: {[name: string]: string} | Map<string, string>}): Translatable | undefined {
-  if (!translatable?.startsWith('%')) {
+  if (!translatable) {
     return translatable;
   }
 
-  const remoteTranslatable = `%workbench.external.~${config.appSymbolicName}~.${translatable.substring(1)}`;
-  const valueParams = Dictionaries.coerce(config.valueParams);
-  const topicParams = Object.fromEntries(Object.entries(Dictionaries.coerce(config.topicParams))
-    // Replace named params in topic segments.
-    .map(([name, topic]) => [name, topic.replace(/(?<=\/|^):(?<namedParam>[^/]+)/g, (match: string, namedParam: string) => `${valueParams[namedParam] ?? match}`)] as const)
-    // Add topic protocol to indicate resolution via topic-based messaging.
-    .map(([paramName, topic]) => [paramName, `${TOPIC_PROTOCOL}${topic}`] as const));
+  // Create Map of value params.
+  const valueParams = new Map(Object.entries(Dictionaries.coerce(config.valueParams)).map(([param, value]) => [param, encodeSemicolons(value)]));
+  // Create Map of topic params, substituting referenced value params.
+  const topicParams = new Map(Object.entries(Dictionaries.coerce(config.topicParams)).map(([param, topic]) => [param, toTopicParam(topic)]));
 
-  // Replace named params in matrix param values.
-  return remoteTranslatable.replace(/(?<==):(?<namedParam>[^;]+)/g, (match: string, namedParam: string) => `${valueParams[namedParam] ?? topicParams[namedParam] ?? match}`);
+  // Return text as-is if not a translation key nor referencing parameters.
+  if (!translatable.startsWith('%') && !containsParam(translatable, valueParams) && !containsParam(translatable, topicParams)) {
+    return translatable;
+  }
+
+  const remoteTranslatablePrefix = `%workbench.external.scion-workbench-client.${config.appSymbolicName}`;
+  if (translatable.startsWith('%')) {
+    // Substitute named parameters in interpolation params.
+    return `${remoteTranslatablePrefix}.${translatable}`.replace(/(?<==):(?<namedParam>[^;]+)/g, (match: string, param: string) => valueParams.get(param) ?? topicParams.get(param) ?? match);
+  }
+  else {
+    // Append referenced parameters in matrix notation.
+    return [...valueParams, ...topicParams]
+      .filter(([param]) => translatable.includes(`:${param}`))
+      .reduce((translatable, [param, value]) => `${translatable};${param}=${value}`, `${remoteTranslatablePrefix}.${encodeSemicolons(translatable)}`);
+  }
+
+  /**
+   * Adds the topic protocol to indicate resolution via topic-based messaging and substitutes named topic segments.
+   */
+  function toTopicParam(topic: string): string {
+    return `${TOPIC_PROTOCOL}${topic.replace(/(?<=\/|^):(?<namedParam>[^/]+)/g, (match: string, namedParam: string) => {
+      return valueParams.get(namedParam) ?? match;
+    })}`;
+  }
+
+  /**
+   * Tests whether the passed text references any of the passed params.
+   */
+  function containsParam(text: string, params: Map<string, unknown>): boolean {
+    return Array.from(params.keys()).some(param => text.includes(`:${param}`));
+  }
 }
 
 /**
  * Prefix of topic params.
  */
 const TOPIC_PROTOCOL = 'topic://';
+
+/**
+ * Encodes semicolons (`;`) as `&#x3b` (Unicode) to prevent interpretation as interpolation parameter separators.
+ */
+function encodeSemicolons(value: unknown): string {
+  return `${value}`.replaceAll(';', '&#x3b');
+}
+
+/**
+ * Decodes encoded semicolons (`&#x3b`) back to semicolons (`;`).
+ */
+function decodeSemicolons(value: string): string {
+  return value.replaceAll('&#x3b', ';');
+}

--- a/projects/scion/workbench/src/lib/notification/notification.config.ts
+++ b/projects/scion/workbench/src/lib/notification/notification.config.ts
@@ -27,7 +27,7 @@ export interface NotificationConfig {
   /**
    * Optional title of the notification.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    *
    * TODO [Angular 21] Passing an Observable is deprecated. To migrate, pass a translatable and provide the text using a text provider registered in `WorkbenchClient.registerTextProvider`. API will be removed in version 21.
    */

--- a/projects/scion/workbench/src/lib/part/workbench-part.model.ts
+++ b/projects/scion/workbench/src/lib/part/workbench-part.model.ts
@@ -46,7 +46,7 @@ export abstract class WorkbenchPart {
    *
    * Note that the title of the top-leftmost part of a docked part cannot be changed.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   public abstract get title(): Signal<Translatable | undefined>;
   public abstract set title(title: Translatable | undefined);

--- a/projects/scion/workbench/src/lib/text/text.spec.ts
+++ b/projects/scion/workbench/src/lib/text/text.spec.ts
@@ -137,9 +137,9 @@ describe('Text Provider', () => {
       ],
     });
 
-    text('%key;param1=v\\;al=ue1;param2=va\\;lue2;pa\\;ram3=val=ue3', {injector: TestBed.inject(Injector)})();
+    text('%key;param1=v\\;al=ue1;param2=va\\;lue2', {injector: TestBed.inject(Injector)})();
     expect(capture.key).toEqual('key');
-    expect(capture.params).toEqual({'param1': 'v;al=ue1', param2: 'va;lue2', 'pa;ram3': 'val=ue3'});
+    expect(capture.params).toEqual({'param1': 'v;al=ue1', param2: 'va;lue2'});
   });
 
   it('should support regex character in parameter value', () => {

--- a/projects/scion/workbench/src/lib/text/text.ts
+++ b/projects/scion/workbench/src/lib/text/text.ts
@@ -104,23 +104,23 @@ function parseMatrixParams(matrixParams: string | undefined): Record<string, str
   }
 
   const params: Record<string, string> = {};
-  for (const match of escapeSemicolon(matrixParams).matchAll(/(?<paramName>[^=;]+)=(?<paramValue>[^;]*)/g)) {
-    const {paramName, paramValue} = match.groups!;
-    params[unescapeSemicolon(paramName!)] = unescapeSemicolon(paramValue!);
+  for (const match of encodeEscapedSemicolons(matrixParams).matchAll(/(?<paramName>[^=;]+)=(?<paramValue>[^;]*)/g)) {
+    const {paramName, paramValue} = match.groups as {paramName: string; paramValue: string};
+    params[paramName] = decodeSemicolons(paramValue);
   }
   return params;
 
   /**
-   * Replaces escaped semicolons (`\;`) with the placeholder (`ɵ`) to prevent interpretation as key-value separators.
+   * Encodes escaped semicolons (`\\;`) as `&#x3b` (Unicode) to prevent interpretation as interpolation parameter separators.
    */
-  function escapeSemicolon(value: string): string {
-    return value.replaceAll('\\;', 'ɵ');
+  function encodeEscapedSemicolons(value: string): string {
+    return value.replaceAll('\\;', '&#x3b');
   }
 
   /**
-   * Restores escaped semicolons by replacing the placeholder (`ɵ`) back to semicolons (`;`).
+   * Decodes encoded semicolons (`&#x3b`) back to semicolons (`;`).
    */
-  function unescapeSemicolon(value: string): string {
-    return value.replaceAll('ɵ', ';');
+  function decodeSemicolons(value: string): string {
+    return value.replaceAll('&#x3b', ';');
   }
 }

--- a/projects/scion/workbench/src/lib/text/workbench-text-provider.model.ts
+++ b/projects/scion/workbench/src/lib/text/workbench-text-provider.model.ts
@@ -34,6 +34,8 @@ export type WorkbenchTextProviderFn = (key: string, params: {[name: string]: str
  * A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
  * Key and parameters are passed to {@link WorkbenchConfig.textProvider} for translation.
  *
+ * Semicolons in interpolation parameters must be escaped with two backslashes (`\\;`).
+ *
  * Examples:
  * - `%key`: translation key
  * - `%key;param=value`: translation key with a single interpolation parameter

--- a/projects/scion/workbench/src/lib/view/workbench-view.model.ts
+++ b/projects/scion/workbench/src/lib/view/workbench-view.model.ts
@@ -82,7 +82,7 @@ export abstract class WorkbenchView {
   /**
    * Title displayed in the view tab.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   public abstract get title(): Signal<Translatable | null>;
   public abstract set title(title: Translatable | null);
@@ -90,7 +90,7 @@ export abstract class WorkbenchView {
   /**
    * Subtitle displayed in the view tab.
    *
-   * Can be a text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
+   * Can be text or a translation key. A translation key starts with the percent symbol (`%`) and may include parameters in matrix notation for text interpolation.
    */
   public abstract get heading(): Signal<Translatable | null>;
   public abstract set heading(heading: Translatable | null);


### PR DESCRIPTION
Texts in the manifest (such as view and dialog titles) can now reference capability parameters and resolvers using the colon syntax.

```json
{
  "params": [
    {"name": "id", "required": true}
  ],
  "properties": {
    "title": "Product :productName", // `:productName` references a resolver
    "resolve": {
      "productName": "products/:id/name" // `:id` references a capability parameter
    }
  }
}
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #255 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No