### PR TITLE
feat(workbench/part): support activating docked part when adding it to the layout

### DIFF
--- a/apps/workbench-testing-app/src/app/layout-page/create-perspective-page/create-perspective-page.component.ts
+++ b/apps/workbench-testing-app/src/app/layout-page/create-perspective-page/create-perspective-page.component.ts
@@ -136,6 +136,7 @@ export default class CreatePerspectivePageComponent {
           tooltip: dockedPart.extras.tooltip,
           title: dockedPart.extras.title,
           cssClass: dockedPart.extras.cssClass,
+          activate: dockedPart.extras.activate,
           ɵactivityId: dockedPart.extras.ɵactivityId,
         });
       }

--- a/apps/workbench-testing-app/src/app/layout-page/modify-layout-page/modify-layout-page.component.ts
+++ b/apps/workbench-testing-app/src/app/layout-page/modify-layout-page/modify-layout-page.component.ts
@@ -103,6 +103,7 @@ export default class ModifyLayoutPageComponent {
           tooltip: dockedPart.extras.tooltip,
           title: dockedPart.extras.title,
           cssClass: dockedPart.extras.cssClass,
+          activate: dockedPart.extras.activate,
           ɵactivityId: dockedPart.extras.ɵactivityId,
         });
       }

--- a/apps/workbench-testing-app/src/app/layout-page/tables/add-docked-parts/add-docked-parts.component.html
+++ b/apps/workbench-testing-app/src/app/layout-page/tables/add-docked-parts/add-docked-parts.component.html
@@ -7,6 +7,7 @@
   <span>Title</span>
   <span>CSS Class(es)</span>
   <span>Activity ID</span>
+  <span class="checkbox">Activate</span>
   <button (click)="onAddDockedPart()" class="e2e-add" title="Add docked part" sciMaterialIcon>add</button>
 
   @for (dockedPartFormGroup of form.controls.dockedParts.controls; track $index) {
@@ -33,6 +34,8 @@
     <app-multi-value-input [formControl]="dockedPartFormGroup.controls.extras.controls.cssClass" [placeholder]="'class-1 class-2'" class="e2e-class"/>
     <!-- Activity Id -->
     <input [formControl]="dockedPartFormGroup.controls.extras.controls.activityId" [class]="'e2e-activity-id'">
+    <!-- Activate -->
+    <sci-checkbox [formControl]="dockedPartFormGroup.controls.extras.controls.activate" [class]="'e2e-activate'"/>
     <button class="e2e-remove" (click)="onRemoveDockedPart($index)" title="Remove docked part" sciMaterialIcon>remove</button>
   }
 </form>

--- a/apps/workbench-testing-app/src/app/layout-page/tables/add-docked-parts/add-docked-parts.component.scss
+++ b/apps/workbench-testing-app/src/app/layout-page/tables/add-docked-parts/add-docked-parts.component.scss
@@ -5,7 +5,7 @@
 
   > form {
     display: grid;
-    grid-template-columns: 10em repeat(7, 1fr) auto;
+    grid-template-columns: 10em repeat(7, 1fr) min-content auto;
     gap: .5em .75em;
     align-items: center;
 

--- a/apps/workbench-testing-app/src/app/layout-page/tables/add-docked-parts/add-docked-parts.component.ts
+++ b/apps/workbench-testing-app/src/app/layout-page/tables/add-docked-parts/add-docked-parts.component.ts
@@ -17,6 +17,7 @@ import {MultiValueInputComponent} from '../../../multi-value-input/multi-value-i
 import {ActivityId, Translatable} from '@scion/workbench';
 import {parseTypedString} from '../../../common/parse-typed-value.util';
 import {UUID} from '@scion/toolkit/uuid';
+import {SciCheckboxComponent} from '@scion/components.internal/checkbox';
 
 @Component({
   selector: 'app-add-docked-parts',
@@ -26,6 +27,7 @@ import {UUID} from '@scion/toolkit/uuid';
     ReactiveFormsModule,
     SciMaterialIconDirective,
     MultiValueInputComponent,
+    SciCheckboxComponent,
   ],
   providers: [
     {provide: NG_VALUE_ACCESSOR, multi: true, useExisting: forwardRef(() => AddDockedPartsComponent)},
@@ -53,6 +55,7 @@ export class AddDockedPartsComponent implements ControlValueAccessor, Validator 
         tooltip: FormControl<Translatable | undefined>;
         title: FormControl<Translatable | undefined>;
         cssClass: FormControl<string | string[] | undefined>;
+        activate: FormControl<boolean | undefined>;
         activityId: FormControl<ActivityId | undefined>;
       }>;
     }>>([]),
@@ -73,6 +76,7 @@ export class AddDockedPartsComponent implements ControlValueAccessor, Validator 
             tooltip: dockedPartFormGroup.controls.extras.controls.tooltip.value,
             title: parseTypedString(dockedPartFormGroup.controls.extras.controls.title.value)!,
             cssClass: dockedPartFormGroup.controls.extras.controls.cssClass.value,
+            activate: dockedPartFormGroup.controls.extras.controls.activate.value,
             ɵactivityId: dockedPartFormGroup.controls.extras.controls.activityId.value,
           },
         })));
@@ -110,6 +114,7 @@ export class AddDockedPartsComponent implements ControlValueAccessor, Validator 
           tooltip: this._formBuilder.control<Translatable | undefined>(dockedPart.extras.tooltip),
           title: this._formBuilder.control<Translatable | undefined>(dockedPart.extras.title === false ? '<boolean>false</boolean>' : dockedPart.extras.title),
           cssClass: this._formBuilder.control<string | string[] | undefined>(dockedPart.extras.cssClass),
+          activate: this._formBuilder.control<boolean | undefined>(dockedPart.extras.activate),
           activityId: this._formBuilder.control<ActivityId | undefined>(dockedPart.extras.ɵactivityId, activityIdFormatValidator()),
         }),
       }), {emitEvent: options?.emitEvent ?? true});
@@ -160,6 +165,7 @@ export interface DockedPartDescriptor {
     tooltip?: Translatable;
     title?: Translatable | false;
     cssClass?: string | string[];
+    activate?: boolean;
     ɵactivityId?: ActivityId;
   };
 }

--- a/apps/workbench-testing-app/src/app/layout-page/tables/add-parts/add-parts.component.ts
+++ b/apps/workbench-testing-app/src/app/layout-page/tables/add-parts/add-parts.component.ts
@@ -106,9 +106,9 @@ export class AddPartsComponent implements ControlValueAccessor, Validator {
           ratio: this._formBuilder.control<number | undefined>({value: isInitialPart ? undefined : part.relativeTo.ratio, disabled: isInitialPart}),
         }),
         extras: this._formBuilder.group({
-          title: part.extras?.title,
+          title: this._formBuilder.control<Translatable | undefined>(part.extras?.title),
           cssClass: this._formBuilder.control<string | string[] | undefined>(part.extras?.cssClass),
-          activate: part.extras?.activate,
+          activate: this._formBuilder.control<boolean | undefined>(part.extras?.activate),
         }),
       }), {emitEvent: options?.emitEvent ?? true});
   }

--- a/projects/scion/e2e-testing/src/workbench/page-object/layout-page/layout-pages.po.ts
+++ b/projects/scion/e2e-testing/src/workbench/page-object/layout-page/layout-pages.po.ts
@@ -29,6 +29,7 @@ export const LayoutPages = {
       await locator.locator('input.e2e-title').nth(i).fill(dockedPart.title === false ? '<boolean>false</boolean>' : (dockedPart.title ?? ''));
       await locator.locator('app-multi-value-input.e2e-class input').nth(i).fill(coerceArray(dockedPart.cssClass).join(' '));
       await locator.locator('input.e2e-activity-id').nth(i).fill(dockedPart.ɵactivityId ?? '');
+      await new SciCheckboxPO(locator.locator('sci-checkbox.e2e-activate').nth(i)).toggle(dockedPart.activate === true);
     }
   },
   /**

--- a/projects/scion/e2e-testing/src/workbench/page-object/layout-page/layout.model.ts
+++ b/projects/scion/e2e-testing/src/workbench/page-object/layout-page/layout.model.ts
@@ -44,11 +44,11 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
   public addPart(id: string | MAIN_AREA, relativeTo: ReferencePart, extras?: PartExtras): WorkbenchLayout;
   public addPart(id: string, dockTo: DockingArea, extras: DockedPartExtras): WorkbenchLayout;
   public addPart(id: string, reference: ReferencePart | DockingArea, extras?: PartExtras | DockedPartExtras): WorkbenchLayout {
-    if ((reference as Partial<DockingArea>).dockTo) {
-      return this.addDockedPart(id, reference as DockingArea, extras as DockedPartExtras);
+    if ('dockTo' in reference) {
+      return this.addDockedPart(id, reference, extras as DockedPartExtras);
     }
     else {
-      return this._addPart(id, reference as ReferencePart, extras as PartExtras);
+      return this._addPart(id, reference, extras as PartExtras);
     }
   }
 
@@ -74,6 +74,7 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
       tooltip: extras.tooltip,
       title: extras.title,
       cssClass: extras.cssClass,
+      activate: extras.activate,
       ɵactivityId: extras.ɵactivityId,
     });
     return this;
@@ -165,6 +166,7 @@ export interface DockedPartDescriptor {
   tooltip?: Translatable;
   title?: Translatable | false;
   cssClass?: string | string[];
+  activate?: boolean;
   ɵactivityId?: ActivityId;
 }
 

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.spec.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.spec.ts
@@ -4694,6 +4694,31 @@ describe('WorkbenchLayout', () => {
       expect(workbenchLayout.part({partId: 'part.activity-1'}).title).toEqual('Title');
       expect(workbenchLayout.part({partId: 'part.activity-1'}).cssClass).toEqual(['class-1']);
       expect(workbenchLayout.part({partId: 'part.activity-1'}).structural).toBeTrue();
+      expect(workbenchLayout.activityLayout.toolbars.leftTop.activeActivityId).toBeUndefined();
+    });
+
+    it('should activate activity if configured', () => {
+      const workbenchLayout = TestBed.inject(ɵWorkbenchLayoutFactory)
+        .addPart(MAIN_AREA)
+        .addPart('part.activity-1', {dockTo: 'left-top'}, {icon: 'icon', label: 'Label', ɵactivityId: 'activity.1', activate: true});
+
+      expect(workbenchLayout.activityLayout.toolbars.leftTop.activeActivityId).toEqual('activity.1');
+    });
+
+    it('should not activate activity if configured', () => {
+      const workbenchLayout = TestBed.inject(ɵWorkbenchLayoutFactory)
+        .addPart(MAIN_AREA)
+        .addPart('part.activity-1', {dockTo: 'left-top'}, {icon: 'icon', label: 'Label', ɵactivityId: 'activity.1', activate: false});
+
+      expect(workbenchLayout.activityLayout.toolbars.leftTop.activeActivityId).toBeUndefined();
+    });
+
+    it('should not activate activity by default', () => {
+      const workbenchLayout = TestBed.inject(ɵWorkbenchLayoutFactory)
+        .addPart(MAIN_AREA)
+        .addPart('part.activity-1', {dockTo: 'left-top'}, {icon: 'icon', label: 'Label', ɵactivityId: 'activity.1'});
+
+      expect(workbenchLayout.activityLayout.toolbars.leftTop.activeActivityId).toBeUndefined();
     });
 
     it('should change activity panel size', () => {

--- a/projects/scion/workbench/src/lib/layout/workbench-layout.ts
+++ b/projects/scion/workbench/src/lib/layout/workbench-layout.ts
@@ -324,6 +324,10 @@ export interface DockedPartExtras {
    */
   cssClass?: string | string[];
   /**
+   * Controls whether to activate the docked part. Defaults to `false`.
+   */
+  activate?: boolean;
+  /**
    * Internal identifier for the docked part.
    *
    * @docs-private Not public API, intended for internal use only.

--- a/projects/scion/workbench/src/lib/layout/ɵworkbench-layout.ts
+++ b/projects/scion/workbench/src/lib/layout/ɵworkbench-layout.ts
@@ -394,11 +394,11 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
     const alternativeId = isPartId(id) ? (id === MAIN_AREA ? MAIN_AREA_ALTERNATIVE_ID : undefined) : id;
     const workingCopy = this.workingCopy();
 
-    if ((reference as Partial<DockingArea>).dockTo) {
-      workingCopy.__addActivity(partId, reference as DockingArea, {...extras, alternativeId} as DockedPartExtras & {alternativeId?: string});
+    if ('dockTo' in reference) {
+      workingCopy.__addActivity(partId, reference, {...extras, alternativeId} as DockedPartExtras & {alternativeId?: string});
     }
     else {
-      workingCopy.__addPart(partId, reference as ReferencePart, {...extras, alternativeId} as PartExtras & {alternativeId?: string; structural?: boolean});
+      workingCopy.__addPart(partId, reference, {...extras, alternativeId} as PartExtras & {alternativeId?: string; structural?: boolean});
     }
     return workingCopy;
   }
@@ -734,15 +734,17 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
 
     const activityId = extras.ɵactivityId ?? computeActivityId();
     const title = extras.title === false ? undefined : extras.title ?? extras.label;
+    const part = new MPart({
+      id,
+      alternativeId: extras.alternativeId,
+      title,
+      structural: true,
+      views: [],
+      cssClass: extras.cssClass ? Arrays.coerce(extras.cssClass) : undefined,
+    });
+
     this._grids[activityId] = {
-      root: new MPart({
-        id,
-        alternativeId: extras.alternativeId,
-        title,
-        structural: true,
-        views: [],
-        cssClass: extras.cssClass ? Arrays.coerce(extras.cssClass) : undefined,
-      }),
+      root: part,
       activePartId: id,
       referencePartId: id,
     };
@@ -755,6 +757,11 @@ export class ɵWorkbenchLayout implements WorkbenchLayout {
       tooltip: extras.tooltip ?? extras.label,
       cssClass: extras.cssClass,
     });
+
+    // Activate the part.
+    if (extras.activate) {
+      this.__activatePart(part);
+    }
   }
 
   /**


### PR DESCRIPTION
feat(workbench/part): support activating docked part when adding it to the layout

@example
```ts
import {bootstrapApplication} from '@angular/platform-browser';
import {MAIN_AREA, provideWorkbench, WorkbenchLayoutFactory} from '@scion/workbench';

bootstrapApplication(AppComponent, {
  providers: [
    provideWorkbench({
      layout: (factory: WorkbenchLayoutFactory) => factory
        .addPart(MAIN_AREA)
        .addPart('navigator', {dockTo: 'left-top'}, {label: 'Navigator', icon: 'folder', activate: true})
        .navigatePart('navigator', [], {hint: 'navigator'}),
    }),
  ],
});
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
