### PR TITLE
feat(workbench-client): provide workbench element to current microfrontend

### DIFF
--- a/projects/scion/workbench-client/src/lib/dialog/workbench-dialog-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/dialog/workbench-dialog-initializer.ts
@@ -13,6 +13,7 @@ import {ContextService} from '@scion/microfrontend-platform';
 import {ɵDIALOG_CONTEXT, ɵDialogContext} from './ɵworkbench-dialog-context';
 import {WorkbenchDialog} from './workbench-dialog';
 import {ɵWorkbenchDialog} from './ɵworkbench-dialog';
+import {WORKBENCH_ELEMENT} from '../workbench.model';
 
 /**
  * Registers {@link WorkbenchDialog} in the bean manager if in the context of a workbench dialog.
@@ -25,7 +26,7 @@ export class WorkbenchDialogInitializer implements Initializer {
     const dialogContext = await Beans.get(ContextService).lookup<ɵDialogContext>(ɵDIALOG_CONTEXT);
     if (dialogContext !== null) {
       Beans.register(WorkbenchDialog, {useValue: new ɵWorkbenchDialog(dialogContext)});
-      Beans.register(Symbol.for('WORKBENCH_ELEMENT'), {useExisting: WorkbenchDialog});
+      Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchDialog});
     }
   }
 }

--- a/projects/scion/workbench-client/src/lib/dialog/ɵworkbench-dialog-service.ts
+++ b/projects/scion/workbench-client/src/lib/dialog/ɵworkbench-dialog-service.ts
@@ -15,7 +15,7 @@ import {catchError, firstValueFrom, throwError} from 'rxjs';
 import {WorkbenchDialogOptions} from './workbench-dialog.options';
 import {Defined, Maps} from '@scion/toolkit/util';
 import {WorkbenchDialogService} from './workbench-dialog-service';
-import {WorkbenchElement} from '../workbench.identifiers';
+import {WORKBENCH_ELEMENT, WorkbenchElement} from '../workbench.model';
 import {ɵWorkbenchDialogCommand} from './workbench-dialog-command';
 
 /**
@@ -34,7 +34,7 @@ export class ɵWorkbenchDialogService implements WorkbenchDialogService {
       context: (() => {
         // TODO [Angular 22] Remove backward compatiblity.
         const context = options?.context && (typeof options.context === 'object' ? options.context.viewId : options.context);
-        return Defined.orElse(context, () => Beans.opt<WorkbenchElement>(Symbol.for('WORKBENCH_ELEMENT'))?.id);
+        return Defined.orElse(context, () => Beans.opt<WorkbenchElement>(WORKBENCH_ELEMENT)?.id);
       })(),
     };
 

--- a/projects/scion/workbench-client/src/lib/message-box/workbench-message-box-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/message-box/workbench-message-box-initializer.ts
@@ -13,6 +13,7 @@ import {ContextService} from '@scion/microfrontend-platform';
 import {ɵWorkbenchMessageBox} from './ɵworkbench-message-box';
 import {WorkbenchMessageBox} from './workbench-message-box';
 import {ɵMESSAGE_BOX_CONTEXT, ɵMessageBoxContext} from './ɵworkbench-message-box-context';
+import {WORKBENCH_ELEMENT} from '../workbench.model';
 
 /**
  * Registers {@link WorkbenchMessageBox} in the bean manager if in the context of a workbench message box.
@@ -25,7 +26,7 @@ export class WorkbenchMessageBoxInitializer implements Initializer {
     const messageBoxContext = await Beans.get(ContextService).lookup<ɵMessageBoxContext>(ɵMESSAGE_BOX_CONTEXT);
     if (messageBoxContext !== null) {
       Beans.register(WorkbenchMessageBox, {useValue: new ɵWorkbenchMessageBox(messageBoxContext)});
-      Beans.register(Symbol.for('WORKBENCH_ELEMENT'), {useExisting: WorkbenchMessageBox});
+      Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchMessageBox});
     }
   }
 }

--- a/projects/scion/workbench-client/src/lib/message-box/ɵworkbench-message-box-service.ts
+++ b/projects/scion/workbench-client/src/lib/message-box/ɵworkbench-message-box-service.ts
@@ -17,7 +17,7 @@ import {catchError, firstValueFrom, throwError} from 'rxjs';
 import {eMESSAGE_BOX_MESSAGE_PARAM} from './workbench-message-box-capability';
 import {WorkbenchMessageBoxService} from './workbench-message-box-service';
 import {Translatable} from '../text/workbench-text-provider.model';
-import {WorkbenchElement} from '../workbench.identifiers';
+import {WORKBENCH_ELEMENT, WorkbenchElement} from '../workbench.model';
 import {ɵWorkbenchMessageBoxCommand} from './workbench-message-box-command';
 
 /**
@@ -46,7 +46,7 @@ export class ɵWorkbenchMessageBoxService implements WorkbenchMessageBoxService 
       context: (() => {
         // TODO [Angular 22] Remove backward compatiblity.
         const context = options?.context && (typeof options.context === 'object' ? options.context.viewId : options.context);
-        return Defined.orElse(context, () => Beans.opt<WorkbenchElement>(Symbol.for('WORKBENCH_ELEMENT'))?.id);
+        return Defined.orElse(context, () => Beans.opt<WorkbenchElement>(WORKBENCH_ELEMENT)?.id);
       })(),
     };
 

--- a/projects/scion/workbench-client/src/lib/part/workbench-part-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/part/workbench-part-initializer.ts
@@ -13,6 +13,7 @@ import {ContextService} from '@scion/microfrontend-platform';
 import {ɵWorkbenchPart} from './ɵworkbench-part';
 import {WorkbenchPart} from './workbench-part';
 import {ɵWORKBENCH_PART_CONTEXT, ɵWorkbenchPartContext} from './ɵworkbench-part-context';
+import {WORKBENCH_ELEMENT} from '../workbench.model';
 
 /**
  * Registers {@link WorkbenchPart} in the bean manager if in the context of a workbench part.
@@ -25,7 +26,7 @@ export class WorkbenchPartInitializer implements Initializer {
     const partContext = await Beans.get(ContextService).lookup<ɵWorkbenchPartContext>(ɵWORKBENCH_PART_CONTEXT);
     if (partContext !== null) {
       Beans.register(WorkbenchPart, {useValue: new ɵWorkbenchPart(partContext)});
-      Beans.register(Symbol.for('WORKBENCH_ELEMENT'), {useExisting: WorkbenchPart});
+      Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchPart});
     }
   }
 }

--- a/projects/scion/workbench-client/src/lib/popup/workbench-popup-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/popup/workbench-popup-initializer.ts
@@ -13,6 +13,7 @@ import {ContextService} from '@scion/microfrontend-platform';
 import {WorkbenchPopup} from './workbench-popup';
 import {ɵPOPUP_CONTEXT, ɵPopupContext} from './workbench-popup-context';
 import {ɵWorkbenchPopup} from './ɵworkbench-popup';
+import {WORKBENCH_ELEMENT} from '../workbench.model';
 
 /**
  * Registers {@link WorkbenchPopup} in the bean manager if in the context of a workbench popup.
@@ -25,7 +26,7 @@ export class WorkbenchPopupInitializer implements Initializer {
     const popupContext = await Beans.get(ContextService).lookup<ɵPopupContext>(ɵPOPUP_CONTEXT);
     if (popupContext !== null) {
       Beans.register(WorkbenchPopup, {useValue: new ɵWorkbenchPopup(popupContext)});
-      Beans.register(Symbol.for('WORKBENCH_ELEMENT'), {useExisting: WorkbenchPopup});
+      Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchPopup});
     }
   }
 }

--- a/projects/scion/workbench-client/src/lib/popup/ɵworkbench-popup-service.ts
+++ b/projects/scion/workbench-client/src/lib/popup/ɵworkbench-popup-service.ts
@@ -19,7 +19,8 @@ import {ɵWorkbenchPopupCommand} from './workbench-popup-command';
 import {ɵWorkbenchCommands} from '../ɵworkbench-commands';
 import {WorkbenchPopupConfig} from './workbench-popup.config';
 import {PopupOrigin} from './popup.origin';
-import {computePopupId, WorkbenchElement} from '../workbench.identifiers';
+import {computePopupId} from '../workbench.identifiers';
+import {WORKBENCH_ELEMENT, WorkbenchElement} from '../workbench.model';
 import {WorkbenchPopupService} from './workbench-popup-service';
 
 /**
@@ -38,7 +39,7 @@ export class ɵWorkbenchPopupService implements WorkbenchPopupService {
       context: (() => {
         // TODO [Angular 22] Remove backward compatiblity.
         const context = config.context && (typeof config.context === 'object' ? config.context.viewId : config.context);
-        return Defined.orElse(context, () => Beans.opt<WorkbenchElement>(Symbol.for('WORKBENCH_ELEMENT'))?.id);
+        return Defined.orElse(context, () => Beans.opt<WorkbenchElement>(WORKBENCH_ELEMENT)?.id);
       })(),
     };
     const popupOriginReporter = this.observePopupOrigin$(config)

--- a/projects/scion/workbench-client/src/lib/public_api.ts
+++ b/projects/scion/workbench-client/src/lib/public_api.ts
@@ -12,6 +12,7 @@ export {WorkbenchClient} from './workbench-client';
 export {WorkbenchCapabilities} from './workbench-capabilities.enum';
 export {ɵWorkbenchCommands} from './ɵworkbench-commands';
 export {type ViewId, type PartId, type DialogId, type PopupId, type ActivityId} from './workbench.identifiers';
+export {type WorkbenchElement, WORKBENCH_ELEMENT} from './workbench.model';
 
 export * from './common/public_api';
 export * from './dialog/public_api';

--- a/projects/scion/workbench-client/src/lib/view/workbench-view-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/view/workbench-view-initializer.ts
@@ -12,6 +12,7 @@ import {Beans, Initializer} from '@scion/toolkit/bean-manager';
 import {ContextService} from '@scion/microfrontend-platform';
 import {WorkbenchView} from './workbench-view';
 import {ɵVIEW_ID_CONTEXT_KEY, ɵWorkbenchView} from './ɵworkbench-view';
+import {WORKBENCH_ELEMENT} from '../workbench.model';
 import {ViewId} from '../workbench.identifiers';
 
 /**
@@ -26,7 +27,7 @@ export class WorkbenchViewInitializer implements Initializer {
     if (viewId !== null) {
       const workbenchView = new ɵWorkbenchView(viewId);
       Beans.register(WorkbenchView, {useValue: workbenchView});
-      Beans.register(Symbol.for('WORKBENCH_ELEMENT'), {useExisting: WorkbenchView});
+      Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchView});
       // Wait until initialized the view, supporting synchronous access to view properties in microfrontend constructor.
       await workbenchView.whenProperties;
     }

--- a/projects/scion/workbench-client/src/lib/workbench.identifiers.ts
+++ b/projects/scion/workbench-client/src/lib/workbench.identifiers.ts
@@ -9,10 +9,6 @@
  */
 
 import {UUID} from '@scion/toolkit/uuid';
-import {WorkbenchPart} from './part/workbench-part';
-import {WorkbenchView} from './view/workbench-view';
-import {WorkbenchDialog} from './dialog/workbench-dialog';
-import {WorkbenchPopup} from './popup/workbench-popup';
 
 /**
  * Format of a view identifier.
@@ -54,8 +50,3 @@ export type ActivityId = `activity.${string}`;
 export function computePopupId(): PopupId {
   return `popup.${UUID.randomUUID().substring(0, 8)}`;
 }
-
-/**
- * Union of workbench elements.
- */
-export type WorkbenchElement = WorkbenchPart | WorkbenchView | WorkbenchDialog | WorkbenchPopup;

--- a/projects/scion/workbench-client/src/lib/workbench.model.ts
+++ b/projects/scion/workbench-client/src/lib/workbench.model.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018-2025 Swiss Federal Railways
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import {WorkbenchPart} from './part/workbench-part';
+import {WorkbenchView} from './view/workbench-view';
+import {WorkbenchDialog} from './dialog/workbench-dialog';
+import {WorkbenchPopup} from './popup/workbench-popup';
+
+/**
+ * Union of workbench elements.
+ */
+export type WorkbenchElement = WorkbenchPart | WorkbenchView | WorkbenchDialog | WorkbenchPopup;
+
+/**
+ * Symbol to inject the workbench element available in the current context.
+ *
+ * @see WorkbenchElement
+ */
+export const WORKBENCH_ELEMENT = Symbol('WORKBENCH_ELEMENT');

--- a/projects/scion/workbench/src/lib/workbench.identifiers.ts
+++ b/projects/scion/workbench/src/lib/workbench.identifiers.ts
@@ -23,15 +23,6 @@ export const WORKBENCH_ID = new InjectionToken<string>('WORKBENCH_ID', {
 });
 
 /**
- * Format of a view identifier.
- *
- * Each view is assigned a unique identifier (e.g., `view.d4de99fb`, `view.cad347dd`, etc.).
- * A view can also have an alternative id, a meaningful but not necessarily unique name. A view can
- * be identified either by its unique or alternative id.
- */
-export type ViewId = `${typeof VIEW_ID_PREFIX}${string}`;
-
-/**
  * Format of a part identifier.
  *
  * Each part is assigned a unique identifier (e.g., `part.9fdf7ab4`, `part.c6485225`, etc.).
@@ -39,6 +30,15 @@ export type ViewId = `${typeof VIEW_ID_PREFIX}${string}`;
  * be identified either by its unique or alternative id.
  */
 export type PartId = `${typeof PART_ID_PREFIX}${string}`;
+
+/**
+ * Format of a view identifier.
+ *
+ * Each view is assigned a unique identifier (e.g., `view.d4de99fb`, `view.cad347dd`, etc.).
+ * A view can also have an alternative id, a meaningful but not necessarily unique name. A view can
+ * be identified either by its unique or alternative id.
+ */
+export type ViewId = `${typeof VIEW_ID_PREFIX}${string}`;
 
 /**
  * Format of a dialog identifier.


### PR DESCRIPTION
A microfrontend can inject its workbench element using the symbol `WORKBENCH_ELEMENT`.

```ts
import {Beans} from '@scion/toolkit/bean-manager';
import {WORKBENCH_ELEMENT, WorkbenchElement} from '@scion/workbench-client';

const workbenchElement = Beans.opt<WorkbenchElement>(WORKBENCH_ELEMENT);
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
