### PR TITLE
fix(workbench): prevent crash on text provider error

### DIFF
--- a/apps/workbench-client-testing-app/src/app/activator/storage-text-provider.ts
+++ b/apps/workbench-client-testing-app/src/app/activator/storage-text-provider.ts
@@ -36,6 +36,9 @@ export function provideTextFromStorage(): void {
           take(1),
         );
     }
+    else if (params['options.error']) {
+      throw Error('TEXT_PROVIDER_ERROR');
+    }
     else {
       return sessionStorage.observe$<string | undefined>(`textprovider.texts.${key}`).pipe(substituteParams(params));
     }
@@ -79,6 +82,13 @@ export function provideValueFromStorage(): void {
     const id = request.params!.get('id');
     console.debug(`[TextProvider][${appSymbolicName}] Requesting value: ${id}`);
     return sessionStorage.observe$<string | undefined>(`textprovider.values.${id}`).pipe(take(1));
+  });
+
+  // Register message listener that errors.
+  inject(MessageClient).onMessage(`textprovider/${appSymbolicName}/values/:id/error`, request => {
+    const id = request.params!.get('id');
+    console.debug(`[TextProvider][${appSymbolicName}] Requesting value: ${id}`);
+    throw Error('TEXT_PROVIDER_ERROR');
   });
 }
 

--- a/projects/scion/e2e-testing/src/workbench-client/text-provider.e2e-spec.ts
+++ b/projects/scion/e2e-testing/src/workbench-client/text-provider.e2e-spec.ts
@@ -1455,6 +1455,93 @@ test.describe('Text Provider', () => {
         await expect.poll(() => activityItem.getTooltip()).toEqual('Tooltip - 123;456 - A;B');
       });
 
+      test('should not propagate error', async ({appPO, microfrontendNavigator, consoleLogs}) => {
+        await appPO.navigateTo({microfrontendSupport: true});
+
+        // Register part.
+        await microfrontendNavigator.registerCapability<WorkbenchPartCapability>('app1', {
+          type: 'part',
+          qualifier: {part: 'testee'},
+          properties: {
+            path: 'test-part',
+            title: '%part_title;options.error=true', // instruct provider to error
+            cssClass: 'testee',
+          },
+        });
+
+        // Create perspective.
+        await microfrontendNavigator.createPerspective('app1', {
+          type: 'perspective',
+          qualifier: {perspective: 'testee'},
+          properties: {
+            parts: [
+              {
+                id: 'part.testee',
+                qualifier: {part: 'testee'},
+              },
+            ],
+          },
+        });
+
+        // Expect translation key to be displayed.
+        await expect(appPO.part({cssClass: 'testee'}).bar.title).toHaveText('%part_title');
+
+        // Expected error to be logged.
+        await expect.poll(() => consoleLogs.get({severity: 'error'})).toContainEqual(
+          expect.stringContaining('[TextProviderError][workbench-host-app] Failed to get text \'%%part_title\' from application \'workbench-client-testing-app1\'. Caused by: '),
+        );
+      });
+
+      test('should not propagate error when parameter resolution fails', async ({appPO, microfrontendNavigator, consoleLogs}) => {
+        await appPO.navigateTo({microfrontendSupport: true});
+
+        // Register part.
+        await microfrontendNavigator.registerCapability<WorkbenchPartCapability>('app1', {
+          type: 'part',
+          qualifier: {part: 'testee'},
+          params: [
+            {name: 'id', required: true},
+          ],
+          properties: {
+            path: 'test-pages/text-test-page',
+            title: '%part_title;param=:param',
+            resolve: {
+              param: 'textprovider/workbench-client-testing-app1/values/:id/error', // append error segment to instruct provider to error
+            },
+            cssClass: 'testee',
+          },
+        });
+
+        // Create perspective.
+        await microfrontendNavigator.createPerspective('app1', {
+          type: 'perspective',
+          qualifier: {perspective: 'testee'},
+          properties: {
+            parts: [
+              {
+                id: 'part.testee',
+                qualifier: {part: 'testee'},
+                params: {
+                  id: '123',
+                },
+              },
+            ],
+          },
+        });
+
+        // Provide text.
+        const testPage = new TextTestPagePO(appPO.part({cssClass: 'testee'}));
+        await testPage.provideText('part_title', 'Title - {{param}}');
+
+        // Expect translation key to be displayed.
+        await expect(appPO.part({cssClass: 'testee'}).bar.title).toHaveText('Title - :param');
+
+        // Expected error to be logged.
+        await expect.poll(() => consoleLogs.get({severity: 'error'})).toContainEqual(
+          expect.stringContaining('[TextProviderError] Failed to resolve parameter \':param\' in text \'%%part_title\' from application \'workbench-client-testing-app1\'. Caused by: '),
+        );
+      });
+
       test('should cache texts on re-layout', async ({appPO, microfrontendNavigator, consoleLogs}) => {
         await appPO.navigateTo({microfrontendSupport: true, mainAreaInitialPartId: 'part.initial', logLevel: 'debug'});
 
@@ -1906,6 +1993,52 @@ test.describe('Text Provider', () => {
           await expect(nonDockedPart.bar.title).toHaveText('Title - 123 -  - :undefined');
           await expect.poll(() => activityItem.getTooltip()).toEqual('Tooltip - 123 -  - :undefined');
         });
+      });
+
+      test('should not propagate error when parameter resolution fails', async ({appPO, microfrontendNavigator, consoleLogs}) => {
+        await appPO.navigateTo({microfrontendSupport: true});
+
+        // Register part.
+        await microfrontendNavigator.registerCapability<WorkbenchPartCapability>('app1', {
+          type: 'part',
+          qualifier: {part: 'testee'},
+          params: [
+            {name: 'id', required: true},
+          ],
+          properties: {
+            path: 'test-part',
+            title: 'Title - :param',
+            resolve: {
+              param: 'textprovider/workbench-client-testing-app1/values/:id/error', // append error segment to instruct provider to error
+            },
+            cssClass: 'testee',
+          },
+        });
+
+        // Create perspective.
+        await microfrontendNavigator.createPerspective('app1', {
+          type: 'perspective',
+          qualifier: {perspective: 'testee'},
+          properties: {
+            parts: [
+              {
+                id: 'part.testee',
+                qualifier: {part: 'testee'},
+                params: {
+                  id: '123',
+                },
+              },
+            ],
+          },
+        });
+
+        // Expect translation key to be displayed.
+        await expect(appPO.part({cssClass: 'testee'}).bar.title).toHaveText('Title - :param');
+
+        // Expected error to be logged.
+        await expect.poll(() => consoleLogs.get({severity: 'error'})).toContainEqual(
+          expect.stringContaining('[TextProviderError] Failed to resolve parameter \':param\' in text \'Title - :param\' from application \'workbench-client-testing-app1\'. Caused by: '),
+        );
       });
 
       test('should support semicolon in text, parameter and resolver', async ({appPO, microfrontendNavigator}) => {
@@ -3660,6 +3793,68 @@ test.describe('Text Provider', () => {
         await expect(testPage.view.tab.heading).toHaveText('Heading - 123;456 - A;B');
       });
 
+      test('should not propagate error', async ({appPO, microfrontendNavigator, consoleLogs}) => {
+        await appPO.navigateTo({microfrontendSupport: true});
+
+        // Register test view.
+        await microfrontendNavigator.registerCapability<WorkbenchViewCapability>('app1', {
+          type: 'view',
+          qualifier: {component: 'testee'},
+          properties: {
+            path: 'test-view',
+            title: '%view_title;options.error=true', // instruct provider to error
+          },
+        });
+
+        // Open test view.
+        const routerPage = await microfrontendNavigator.openInNewTab(RouterPagePO, 'app1');
+        await routerPage.navigate({component: 'testee'}, {cssClass: 'testee'});
+
+        // Expect translation key to be displayed.
+        await expect(appPO.view({cssClass: 'testee'}).tab.title).toHaveText('%view_title');
+
+        // Expected error to be logged.
+        await expect.poll(() => consoleLogs.get({severity: 'error'})).toContainEqual(
+          expect.stringContaining('[TextProviderError][workbench-host-app] Failed to get text \'%%view_title\' from application \'workbench-client-testing-app1\'. Caused by: '),
+        );
+      });
+
+      test('should not propagate error when parameter resolution fails', async ({appPO, microfrontendNavigator, consoleLogs}) => {
+        await appPO.navigateTo({microfrontendSupport: true});
+
+        // Register test view.
+        await microfrontendNavigator.registerCapability<WorkbenchViewCapability>('app1', {
+          type: 'view',
+          qualifier: {component: 'testee'},
+          params: [
+            {name: 'id', required: true},
+          ],
+          properties: {
+            path: 'test-pages/text-test-page',
+            title: '%view_title;param=:param',
+            resolve: {
+              param: 'textprovider/workbench-client-testing-app1/values/:id/error', // append error segment to instruct provider to error
+            },
+          },
+        });
+
+        // Open test view.
+        const routerPage = await microfrontendNavigator.openInNewTab(RouterPagePO, 'app1');
+        await routerPage.navigate({component: 'testee'}, {params: {id: '123'}, cssClass: 'testee'});
+        const testPage = new TextTestPagePO(appPO.view({cssClass: 'testee'}));
+
+        // Provide text.
+        await testPage.provideText('view_title', 'Title - {{param}}');
+
+        // Expect translation key to be displayed.
+        await expect(testPage.view.tab.title).toHaveText('Title - :param');
+
+        // Expected error to be logged.
+        await expect.poll(() => consoleLogs.get({severity: 'error'})).toContainEqual(
+          expect.stringContaining('[TextProviderError] Failed to resolve parameter \':param\' in text \'%%view_title\' from application \'workbench-client-testing-app1\'. Caused by: '),
+        );
+      });
+
       test('should display localized title and heading set via handle', async ({appPO, microfrontendNavigator}) => {
         await appPO.navigateTo({microfrontendSupport: true});
 
@@ -3947,6 +4142,38 @@ test.describe('Text Provider', () => {
           await expect(testPage.view.tab.title).toHaveText('Title - 123 -  - :undefined');
           await expect(testPage.view.tab.heading).toHaveText('Heading - 123 -  - :undefined');
         });
+      });
+
+      test('should not propagate error when parameter resolution fails', async ({appPO, microfrontendNavigator, consoleLogs}) => {
+        await appPO.navigateTo({microfrontendSupport: true});
+
+        // Register test view.
+        await microfrontendNavigator.registerCapability<WorkbenchViewCapability>('app1', {
+          type: 'view',
+          qualifier: {component: 'testee'},
+          params: [
+            {name: 'id', required: true},
+          ],
+          properties: {
+            path: 'test-view',
+            title: 'Title - :param',
+            resolve: {
+              param: 'textprovider/workbench-client-testing-app1/values/:id/error', // append error segment to instruct provider to error
+            },
+          },
+        });
+
+        // Open test view.
+        const routerPage = await microfrontendNavigator.openInNewTab(RouterPagePO, 'app1');
+        await routerPage.navigate({component: 'testee'}, {params: {id: '123'}, cssClass: 'testee'});
+
+        // Expect translation key to be displayed.
+        await expect(appPO.view({cssClass: 'testee'}).tab.title).toHaveText('Title - :param');
+
+        // Expected error to be logged.
+        await expect.poll(() => consoleLogs.get({severity: 'error'})).toContainEqual(
+          expect.stringContaining('[TextProviderError] Failed to resolve parameter \':param\' in text \'Title - :param\' from application \'workbench-client-testing-app1\'. Caused by: '),
+        );
       });
 
       test('should support semicolon in text, parameter and resolver', async ({appPO, microfrontendNavigator}) => {

--- a/projects/scion/workbench-client/src/lib/text/ɵworkbench-text.service.ts
+++ b/projects/scion/workbench-client/src/lib/text/ɵworkbench-text.service.ts
@@ -61,7 +61,7 @@ export class ɵWorkbenchTextService implements WorkbenchTextService, PreDestroy 
         waitUntilRegisteredTextProvider(options.provider, {timeout: 60_000}),
         catchError((error: unknown) => {
           // Prefix the key with an additional `%` character to escape the leading `%` character. See console formatting rules: https://developer.mozilla.org/en-US/docs/Web/API/console
-          console.error(`[NullTextError][${Beans.get(APP_IDENTITY)}] Failed to get text '%${translatable}' from application '${options.provider}'. Caused by: `, error);
+          console.error(`[TextProviderError][${Beans.get(APP_IDENTITY)}] Failed to get text '%${translatable}' from application '${options.provider}'. Caused by: `, error);
           return of(`%${key}`);
         }),
         // Remove cached text when an error occurs, or when the subscriber count drops to zero, after the specified TTL.

--- a/projects/scion/workbench/src/lib/microfrontend-platform/microfrontend-text/remote-text-provider.ts
+++ b/projects/scion/workbench/src/lib/microfrontend-platform/microfrontend-text/remote-text-provider.ts
@@ -9,14 +9,15 @@
  */
 
 import {Translatable, WORKBENCH_TEXT_PROVIDER, WorkbenchTextProviderFn} from '../../text/workbench-text-provider.model';
-import {EnvironmentProviders, makeEnvironmentProviders, Signal} from '@angular/core';
+import {EnvironmentProviders, inject, makeEnvironmentProviders, Signal} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {animationFrameScheduler, combineLatest, concatWith, map, NEVER, Observable, of, ReplaySubject, share, switchMap, timer} from 'rxjs';
 import {Beans} from '@scion/toolkit/bean-manager';
 import {mapToBody, MessageClient} from '@scion/microfrontend-platform';
 import {WorkbenchTextService} from '@scion/workbench-client';
 import {Dictionaries} from '@scion/toolkit/util';
-import {finalize} from 'rxjs/operators';
+import {catchError, finalize} from 'rxjs/operators';
+import {Logger, LoggerNames} from '../../logging';
 
 /**
  * Registers a text provider for the SCION Workbench to get texts from micro apps.
@@ -63,7 +64,7 @@ export function provideRemoteTextProvider(): EnvironmentProviders {
     }
 
     // Request the text by intent. Parameters starting with the topic protocol 'topic://' are resolved via messaging.
-    const text$ = observeParams$(params, {provider})
+    const text$ = observeParams$(params, {provider, translatable: `%${key}`})
       .pipe(
         // Ensure the observable to never complete independent of text provider request completion, simplifying cache cleanup as
         // finalize is only called when the last subscriber unsubscribes, after the specified TTL.
@@ -102,7 +103,7 @@ export function provideRemoteTextProvider(): EnvironmentProviders {
     }
 
     // Substitute params. Parameters starting with the topic protocol 'topic://' are resolved via messaging.
-    const text$ = observeParams$(params, {provider})
+    const text$ = observeParams$(params, {provider, translatable: text})
       .pipe(
         // Never complete the observable, simplifying cache cleanup as `finalize` is only called when the last subscriber unsubscribes, after the specified TTL.
         concatWith(NEVER),
@@ -124,7 +125,8 @@ export function provideRemoteTextProvider(): EnvironmentProviders {
    *
    * Parameters starting with the topic protocol 'topic://' are resolved via topic-based messaging.
    */
-  function observeParams$(params: {[name: string]: string | `topic://${string}`}, options: {provider: string}): Observable<Array<[string, string]>> {
+  function observeParams$(params: {[name: string]: string | `topic://${string}`}, options: {provider: string; translatable: string}): Observable<Array<[string, string]>> {
+    const logger = inject(Logger);
     const observableParams: Array<Observable<[string, string]>> = Object.entries(params).map(([param, value]) => {
       if (!value.startsWith(TOPIC_PROTOCOL)) {
         return of([param, value]);
@@ -136,7 +138,13 @@ export function provideRemoteTextProvider(): EnvironmentProviders {
           mapToBody(),
           // Resolve text if the resolver returns a translatable.
           switchMap(resolved => resolved?.startsWith('%') ? Beans.get(WorkbenchTextService).text$(resolved, options) : of(resolved)),
-          map(resolved => [param, resolved ?? '']),
+          map(resolved => [param, resolved ?? ''] satisfies [string, string]),
+          // Do not propagate error to still display text and valid parameters.
+          catchError(error => {
+            // Prefix the key with an additional `%` character to escape the leading `%` character. See console formatting rules: https://developer.mozilla.org/en-US/docs/Web/API/console
+            logger.error(`[TextProviderError] Failed to resolve parameter ':${param}' in text '${options.translatable.startsWith('%') ? `%${options.translatable}` : options.translatable}' from application '${options.provider}'. Caused by: `, error, LoggerNames.MICROFRONTEND);
+            return of([param, `:${param}`] satisfies [string, string]);
+          }),
         );
     });
 

--- a/projects/scion/workbench/src/lib/text/text.pipe.spec.ts
+++ b/projects/scion/workbench/src/lib/text/text.pipe.spec.ts
@@ -159,6 +159,39 @@ describe('Text Pipe', () => {
     expect(textCaptor1.destroyed).toBeTrue();
     expect(textCaptor2.destroyed).toBeUndefined();
   });
+
+  it('should not propagate error', async () => {
+    // Spy console.
+    spyOn(console, 'error').and.callThrough();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideTextProvider(() => {
+          throw error;
+        }),
+        {provide: ComponentFixtureAutoDetect, useValue: true},
+      ],
+    });
+
+    @Component({
+      selector: 'spec-testee',
+      template: '{{(\'%key\' | wbText)()}}',
+      imports: [
+        TextPipe,
+      ],
+    })
+    class SpecRootComponent {
+    }
+
+    const error = Error('UNEXPECTED');
+    const fixture = TestBed.createComponent(SpecRootComponent);
+    await fixture.whenStable();
+
+    // Expect key to be displayed.
+    expect(fixture.debugElement.nativeElement.innerText).toEqual('%key');
+    // Expected error to be logged.
+    expect(console.error).toHaveBeenCalledWith(jasmine.stringContaining('[TextProviderError] Failed to get text for \'%%key\'. Caused by:'), error);
+  });
 });
 
 function provideTextProvider(textProvider: WorkbenchTextProviderFn): EnvironmentProviders {

--- a/projects/scion/workbench/src/lib/text/text.spec.ts
+++ b/projects/scion/workbench/src/lib/text/text.spec.ts
@@ -473,6 +473,50 @@ describe('Text Provider', () => {
     injector.destroy();
     expect(destroyed).toBeTrue();
   });
+
+  it('should not propagate error', () => {
+    // Spy console.
+    spyOn(console, 'error').and.callThrough();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideTextProvider(() => {
+          throw error;
+        }),
+      ],
+    });
+
+    const error = Error('UNEXPECTED');
+    const translated = text('%key', {injector: TestBed.inject(Injector)});
+
+    // Expect key to be returned.
+    expect(translated()).toEqual('%key');
+    // Expected error to be logged.
+    expect(console.error).toHaveBeenCalledWith(jasmine.stringContaining('[TextProviderError] Failed to get text for \'%%key\'. Caused by:'), error);
+  });
+
+  it('should not propagate error (text as signal)', () => {
+    // Spy console.
+    spyOn(console, 'error').and.callThrough();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideTextProvider(() => {
+          return computed(() => {
+            throw error;
+          });
+        }),
+      ],
+    });
+
+    const error = Error('UNEXPECTED');
+    const translated = text('%key', {injector: TestBed.inject(Injector)});
+
+    // Expect key to be returned.
+    expect(translated()).toEqual('%key');
+    // Expected error to be logged.
+    expect(console.error).toHaveBeenCalledWith(jasmine.stringContaining('[TextProviderError] Failed to get text for \'%%key\'. Caused by:'), error);
+  });
 });
 
 describe('Workbench Text Provider', () => {

--- a/projects/scion/workbench/src/lib/text/text.ts
+++ b/projects/scion/workbench/src/lib/text/text.ts
@@ -71,10 +71,18 @@ function provideText(translatable: Translatable | undefined | null): Signal<stri
   }
 
   const {key, params} = parseTranslatable(translatable as `%${string}`);
+  const errorHandler = (error: unknown): string => {
+    // Prefix the key with an additional `%` character to escape the leading `%` character. See console formatting rules: https://developer.mozilla.org/en-US/docs/Web/API/console
+    console.error(`[TextProviderError] Failed to get text for '%${translatable}'. Caused by:`, error);
+    return translatable;
+  };
+
   for (const textProvider of textProviders) {
-    const text = textProvider(key, params);
+    // If `textProvider` throws an error, `runSafe` catches it and delegates execution to the error handler, logging the error and returning the translatable.
+    const text = runSafe(() => textProvider(key, params), errorHandler);
     if (text !== undefined) {
-      return isSignal(text) ? text : signal(text);
+      // If signal, wrap it in `computed` to handle errors.
+      return isSignal(text) ? computed(() => runSafe(() => text(), errorHandler)) : signal(text);
     }
   }
   return signal(translatable);
@@ -122,5 +130,19 @@ function parseMatrixParams(matrixParams: string | undefined): Record<string, str
    */
   function decodeSemicolons(value: string): string {
     return value.replaceAll('&#x3b', ';');
+  }
+}
+
+/**
+ * Runs the passed function.
+ *
+ * If the function throws an error, catches the error and delegates execution to the passed error handler, returning the handler's result.
+ */
+export function runSafe<T>(fn: () => T, onErrorFn: (error: unknown) => T): T {
+  try {
+    return fn();
+  }
+  catch (error) {
+    return onErrorFn(error);
   }
 }


### PR DESCRIPTION
Fixes an issue where a text provider error for a view or part title crashed the workbench, making it impossible for the user to interact with the UI. Errors are now caught and logged, and the translation key is displayed instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
