### PR TITLE
test(workbench): use retries in `toContainFocus` matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "copy-src:scion-components": "cpx --clean --watch --verbose \"../scion-toolkit/projects/scion/components/**\" \"./src-lib/@scion/components\"",
     "copy-src:scion-components.internal": "cpx --clean --watch --verbose \"../scion-toolkit/projects/scion/components.internal/**\" \"./src-lib/@scion/components.internal\"",
     "copy-src:scion-microfrontend-platform": "cpx --clean --watch --verbose \"../scion-microfrontend-platform/projects/scion/microfrontend-platform/**\" \"./src-lib/@scion/microfrontend-platform\"",
+
     "workbench-client:build": "ng build --configuration production @scion/workbench-client",
     "workbench-client:lint": "ng lint @scion/workbench-client",
     "workbench-client:test": "ng test @scion/workbench-client",
@@ -77,6 +78,7 @@
     "workbench-client-testing-app:4202:dist-serve": "serve dist/workbench-client-testing-app-ci/browser -p 4202 --config ../../../apps/workbench-client-testing-app/vercel-test-server.config.json --no-request-logging",
     "workbench-client-testing-app:zone:serve": "ng serve workbench-client-testing-app --configuration=development-zone --port 4203",
     "workbench-client-testing-app:zone:dist-serve": "serve dist/workbench-client-testing-app-zone/browser -p 4203 --config ../../../apps/workbench-client-testing-app/vercel-test-server.config.json --no-request-logging",
+
     "e2e:build": "tsc -p projects/scion/e2e-testing/tsconfig.json",
     "e2e:run": "cross-env PLAYWRIGHT_BROWSERS_PATH=0 playwright test --config projects/scion/e2e-testing/playwright.config.ts",
     "e2e:debug": "cross-env PLAYWRIGHT_BROWSERS_PATH=0 PWDEBUG=1 playwright test --config projects/scion/e2e-testing/playwright.config.ts",

--- a/projects/scion/e2e-testing/src/matcher/to-contain-focus.matcher.ts
+++ b/projects/scion/e2e-testing/src/matcher/to-contain-focus.matcher.ts
@@ -9,11 +9,26 @@
  */
 import {Locator} from '@playwright/test';
 import {MatcherReturnType} from 'playwright/types/test';
+import {retryOnError} from '../helper/testing.util';
 
 /**
  * Provides the implementation of {@link CustomMatchers#toContainFocus}.
  */
 export async function toContainFocus(locator: Locator): Promise<MatcherReturnType> {
+  try {
+    // Retry assertion to behave like a Playwright web-first assertion, i.e., wait and retry until the expected condition is met.
+    await retryOnError(() => assertFocus(locator));
+    return {pass: true, message: () => 'Focus on element or children.'};
+  }
+  catch (error) {
+    return {pass: false, message: () => error instanceof Error ? error.message : `${error}`};
+  }
+}
+
+async function assertFocus(locator: Locator): Promise<void> {
   const focused = await locator.evaluate((element: HTMLElement) => !!document.activeElement && element.contains(document.activeElement));
-  return {pass: focused, message: () => focused ? 'Focus on element or children.' : 'No focus on element or children.'};
+
+  if (!focused) {
+    throw new Error('No focus on element or children.');
+  }
 }


### PR DESCRIPTION
The `toContainFocus` was checking the focus immediately without retries, which lead to flaky tests.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [x] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
