### PR TITLE
fix(workbench-client): ensure that the worbench element handles are correctly destroyed by the bean manager

### DIFF
--- a/projects/scion/workbench-client/src/lib/dialog/workbench-dialog-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/dialog/workbench-dialog-initializer.ts
@@ -25,7 +25,8 @@ export class WorkbenchDialogInitializer implements Initializer {
   public async init(): Promise<void> {
     const dialogContext = await Beans.get(ContextService).lookup<ɵDialogContext>(ɵDIALOG_CONTEXT);
     if (dialogContext !== null) {
-      Beans.register(WorkbenchDialog, {useValue: new ɵWorkbenchDialog(dialogContext)});
+      // Handles must be registered with `useFactory` to support the bean manager's PreDestroy lifecycle hook.
+      Beans.register(WorkbenchDialog, {useFactory: () => new ɵWorkbenchDialog(dialogContext)});
       Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchDialog});
     }
   }

--- a/projects/scion/workbench-client/src/lib/message-box/workbench-message-box-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/message-box/workbench-message-box-initializer.ts
@@ -25,7 +25,8 @@ export class WorkbenchMessageBoxInitializer implements Initializer {
   public async init(): Promise<void> {
     const messageBoxContext = await Beans.get(ContextService).lookup<ɵMessageBoxContext>(ɵMESSAGE_BOX_CONTEXT);
     if (messageBoxContext !== null) {
-      Beans.register(WorkbenchMessageBox, {useValue: new ɵWorkbenchMessageBox(messageBoxContext)});
+      // Handles must be registered with `useFactory` to support the bean manager's PreDestroy lifecycle hook.
+      Beans.register(WorkbenchMessageBox, {useFactory: () => new ɵWorkbenchMessageBox(messageBoxContext)});
       Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchMessageBox});
     }
   }

--- a/projects/scion/workbench-client/src/lib/notification/workbench-notification-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/notification/workbench-notification-initializer.ts
@@ -25,7 +25,8 @@ export class WorkbenchNotificationInitializer implements Initializer {
   public async init(): Promise<void> {
     const notificationContext = await Beans.get(ContextService).lookup<ɵNotificationContext>(ɵNOTIFICATION_CONTEXT);
     if (notificationContext !== null) {
-      Beans.register(WorkbenchNotification, {useValue: new ɵWorkbenchNotification(notificationContext)});
+      // Handles must be registered with `useFactory` to support the bean manager's PreDestroy lifecycle hook.
+      Beans.register(WorkbenchNotification, {useFactory: () => new ɵWorkbenchNotification(notificationContext)});
       Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchNotification});
     }
   }

--- a/projects/scion/workbench-client/src/lib/part/workbench-part-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/part/workbench-part-initializer.ts
@@ -25,7 +25,8 @@ export class WorkbenchPartInitializer implements Initializer {
   public async init(): Promise<void> {
     const partContext = await Beans.get(ContextService).lookup<ɵWorkbenchPartContext>(ɵWORKBENCH_PART_CONTEXT);
     if (partContext !== null) {
-      Beans.register(WorkbenchPart, {useValue: new ɵWorkbenchPart(partContext)});
+      // Handles must be registered with `useFactory` to support the bean manager's PreDestroy lifecycle hook.
+      Beans.register(WorkbenchPart, {useFactory: () => new ɵWorkbenchPart(partContext)});
       Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchPart});
     }
   }

--- a/projects/scion/workbench-client/src/lib/popup/workbench-popup-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/popup/workbench-popup-initializer.ts
@@ -25,7 +25,8 @@ export class WorkbenchPopupInitializer implements Initializer {
   public async init(): Promise<void> {
     const popupContext = await Beans.get(ContextService).lookup<ɵPopupContext>(ɵPOPUP_CONTEXT);
     if (popupContext !== null) {
-      Beans.register(WorkbenchPopup, {useValue: new ɵWorkbenchPopup(popupContext)});
+      // Handles must be registered with `useFactory` to support the bean manager's PreDestroy lifecycle hook.
+      Beans.register(WorkbenchPopup, {useFactory: () => new ɵWorkbenchPopup(popupContext)});
       Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchPopup});
     }
   }

--- a/projects/scion/workbench-client/src/lib/view/workbench-view-initializer.ts
+++ b/projects/scion/workbench-client/src/lib/view/workbench-view-initializer.ts
@@ -25,11 +25,11 @@ export class WorkbenchViewInitializer implements Initializer {
   public async init(): Promise<void> {
     const viewId = await Beans.get(ContextService).lookup<ViewId>(ɵVIEW_ID_CONTEXT_KEY);
     if (viewId !== null) {
-      const workbenchView = new ɵWorkbenchView(viewId);
-      Beans.register(WorkbenchView, {useValue: workbenchView});
+      // Handles must be registered with `useFactory` to support the bean manager's PreDestroy lifecycle hook.
+      Beans.register(WorkbenchView, {useFactory: () => new ɵWorkbenchView(viewId)});
       Beans.register(WORKBENCH_ELEMENT, {useExisting: WorkbenchView});
       // Wait until initialized the view, supporting synchronous access to view properties in microfrontend constructor.
-      await workbenchView.whenProperties;
+      await Beans.get<ɵWorkbenchView>(WorkbenchView).whenProperties;
     }
   }
 }


### PR DESCRIPTION
The @scion/toolkit bean manager does not invoke the `PreDestroy` lifecycle hook for beans registered with the `useValue` instruction. However, the workbench-client handles rely on this lifecycle hook for cleanup logic.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-workbench/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

